### PR TITLE
Changed sign on load values. Convert price unit to euro/kWh

### DIFF
--- a/src/d3a/area_statistics.py
+++ b/src/d3a/area_statistics.py
@@ -34,9 +34,10 @@ def gather_area_loads_and_trade_prices(area, load_price_lists):
             for slot, market in child.parent.past_markets.items():
                 if slot.hour not in load_price_lists.keys():
                     load_price_lists[slot.hour] = loads_avg_prices(load=[], price=[])
-                load_price_lists[slot.hour].load.append(market.traded_energy[child.name])
+                load_price_lists[slot.hour].load.append(abs(market.traded_energy[child.name]))
                 trade_prices = [
-                    t.offer.price / t.offer.energy
+                    # Convert from cents to euro
+                    t.offer.price / 100.0 / t.offer.energy
                     for t in market.trades
                     if t.buyer == child.name
                 ]

--- a/src/d3a/web.py
+++ b/src/d3a/web.py
@@ -333,7 +333,7 @@ def _api_app(simulation: Simulation):
     @lock_flask_endpoint
     def cumulative_load():
         return {
-            "price-currency": "Euro Cent",
+            "price-currency": "Euros",
             "load-unit": "kWh",
             "cumulative-load-price": export_cumulative_loads(simulation.area)
         }


### PR DESCRIPTION
In order for the price load chart to be more pleasing to the eye, we need to change the load sign (from negative to positive) and the price unit from cent to euro. 