### PR TITLE
Slot count was incremented by 1, but the for loop range was not.

### DIFF
--- a/src/d3a/simulation.py
+++ b/src/d3a/simulation.py
@@ -152,7 +152,7 @@ class Simulation:
 
             try:
                 with NonBlockingConsole() as console:
-                    for slot_no in range(slot_resume, config.duration // config.slot_length):
+                    for slot_no in range(slot_resume, slot_count):
                         run_duration = (
                             Pendulum.now() - self.run_start - Interval(seconds=self.paused_time)
                         )


### PR DESCRIPTION
Compare the change with line 139 of the same file, slot_count is increased by one to accomodate the last slot. The for loop range though did not include this +1, therefore there were one less slot running per simulation. 