### PR TITLE
Bug/d3 asim 483

### DIFF
--- a/tests/test_strategy_e_car.py
+++ b/tests/test_strategy_e_car.py
@@ -1,6 +1,6 @@
 import pendulum
 import pytest
-
+from unittest.mock import Mock
 from d3a.models.area import DEFAULT_CONFIG
 from d3a.models.market import Offer, Trade
 from d3a.models.strategy.const import ARRIVAL_TIME, DEPART_TIME
@@ -44,6 +44,10 @@ class FakeArea():
     @property
     def past_markets(self):
         return {"past market": self.past_market}
+
+    @property
+    def current_market(self):
+        return self.past_market
 
 
 class FakeMarket:
@@ -126,7 +130,9 @@ def e_car_strategy_test2(area_test2, called):
     e = ECarStrategy()
     e.owner = area_test2
     e.area = area_test2
-    e.depart = called
+    e._remove_offers_on_depart = called
+    e.buy_energy = lambda a: None
+    e.sell_energy = lambda a: None
     e.depart_times_not_reached = list(range(24))
     e.depart_times_not_reached.remove(DEPART_TIME)
     e.depart_times_not_reached.remove(ARRIVAL_TIME)
@@ -134,16 +140,20 @@ def e_car_strategy_test2(area_test2, called):
 
 
 def test_car_depart(e_car_strategy_test2, area_test2):
+    e_car_strategy_test2.connected_to_grid = True
     e_car_strategy_test2.depart_time = DEPART_TIME
     e_car_strategy_test2.event_tick(area=area_test2)
-    assert len(e_car_strategy_test2.depart.calls) == 1
+    assert len(e_car_strategy_test2._remove_offers_on_depart.calls) == 1
+    assert not e_car_strategy_test2.connected_to_grid
 
 
 def test_car_not_depart(e_car_strategy_test2, area_test2):
+    e_car_strategy_test2.connected_to_grid = True
     for i in e_car_strategy_test2.depart_times_not_reached:
         e_car_strategy_test2.depart_time = i
         e_car_strategy_test2.event_tick(area=area_test2)
-        assert len(e_car_strategy_test2.depart.calls) == 0
+        assert len(e_car_strategy_test2._remove_offers_on_depart.calls) == 0
+        assert e_car_strategy_test2.connected_to_grid
 
 
 """TEST3"""
@@ -168,14 +178,21 @@ def e_car_strategy_test4(area_test1, called):
     e = ECarStrategy()
     e.owner = area_test1
     e.area = area_test1
-    e.sell_energy = called
+    e.sell_energy = Mock(return_value=None)
+    e.buy_energy = lambda x: None
+    e.depart = called
     return e
 
 
-def test_ecar_arrival(e_car_strategy_test4):
+def test_ecar_arrival(e_car_strategy_test4, area_test1):
     e_car_strategy_test4.arrive()
     assert e_car_strategy_test4.connected_to_grid
-    assert len(e_car_strategy_test4.sell_energy.calls) == 1
+    assert e_car_strategy_test4.sell_energy.called
+    for i in range(1000):
+        e_car_strategy_test4.event_tick(area=area_test1)
+        assert e_car_strategy_test4.connected_to_grid
+        assert len(e_car_strategy_test4.depart.calls) == 0
+        assert e_car_strategy_test4.sell_energy.call_count == i+2
 
 
 """TEST5"""


### PR DESCRIPTION
The bug actually did reveal an old misconfiguration. [Default.py file](https://github.com/gridsingularity/d3a/blob/master/src/d3a/setup/default.py#L68) is using None as an input for arrival and departure time parameters, therefore the default constructor arguments did not apply. However, since a user can very easily do something like that, a check was added to set the values to default once None is detected.