### PR TITLE
D3ASIM-3653-refactoring: Renamed event 'event_trade' into 'event_offe…

### DIFF
--- a/integration_tests/settlement_market.feature
+++ b/integration_tests/settlement_market.feature
@@ -13,7 +13,6 @@ Feature: Settlement Market Tests
     Then settlement markets are created
     And settlement market trades have been executed
 
-
   Scenario: D3ASIM-3653: Trade events are correctly triggered in the settlement load
     Given we have a scenario named settlement_market/simple_load_cell_tower
     And d3a is installed

--- a/src/d3a/events/__init__.py
+++ b/src/d3a/events/__init__.py
@@ -36,8 +36,8 @@ class EventMixin:
             return self.event_offer_split
         elif event == MarketEvent.OFFER_DELETED:
             return self.event_offer_deleted
-        elif event == MarketEvent.TRADE:
-            return self.event_trade
+        elif event == MarketEvent.OFFER_TRADED:
+            return self.event_offer_traded
         elif event == MarketEvent.BID_TRADED:
             return self.event_bid_traded
         elif event == MarketEvent.BID_DELETED:
@@ -78,8 +78,8 @@ class EventMixin:
     def event_offer_deleted(self, *, market_id, offer):
         pass
 
-    def event_trade(self, *, market_id, trade):
-        """Method triggered by the MarketEvent.TRADE event."""
+    def event_offer_traded(self, *, market_id, trade):
+        """Method triggered by the MarketEvent.OFFER_TRADED event."""
 
     def event_bid_traded(self, *, market_id, bid_trade):
         """Method triggered by the MarketEvent.BID_TRADED event."""

--- a/src/d3a/events/event_structures.py
+++ b/src/d3a/events/event_structures.py
@@ -33,7 +33,7 @@ class MarketEvent(Enum):
     OFFER = 1
     OFFER_SPLIT = 4
     OFFER_DELETED = 2
-    TRADE = 3
+    OFFER_TRADED = 3
     BID_TRADED = 5
     BID_DELETED = 6
     BID_SPLIT = 7

--- a/src/d3a/models/market/one_sided.py
+++ b/src/d3a/models/market/one_sided.py
@@ -312,10 +312,10 @@ class OneSidedMarket(Market):
 
         if already_tracked is False:
             self._update_stats_after_trade(trade, offer)
-            log.info(f"{self._debug_log_market_type_identifier}[TRADE] "
+            log.info(f"{self._debug_log_market_type_identifier}[TRADE][OFFER] "
                      f"[{self.name}] [{self.time_slot_str}] {trade}")
 
         # TODO: Use non-blockchain non-event-driven version for now for both blockchain and
         # normal runs.
-        self._notify_listeners(MarketEvent.TRADE, trade=trade)
+        self._notify_listeners(MarketEvent.OFFER_TRADED, trade=trade)
         return trade

--- a/src/d3a/models/strategy/__init__.py
+++ b/src/d3a/models/strategy/__init__.py
@@ -222,7 +222,7 @@ class BaseStrategy(TriggerMixin, EventMixin, AreaBehaviorBase):
         super(BaseStrategy, self).__init__()
         self.offers = Offers(self)
         self.enabled = True
-        self._allowed_disable_events = [AreaEvent.ACTIVATE, MarketEvent.TRADE]
+        self._allowed_disable_events = [AreaEvent.ACTIVATE, MarketEvent.OFFER_TRADED]
         if ConstSettings.GeneralSettings.EVENT_DISPATCHING_VIA_REDIS:
             self.redis = BlockingCommunicator()
             self.trade_buffer = None
@@ -471,8 +471,10 @@ class BaseStrategy(TriggerMixin, EventMixin, AreaBehaviorBase):
         if self.enabled or event_type in self._allowed_disable_events:
             super().event_listener(event_type, **kwargs)
 
-    def event_trade(self, *, market_id, trade):
-        """React to offer trades. This method is triggered by the MarketEvent.TRADE event."""
+    def event_offer_traded(self, *, market_id, trade):
+        """
+        React to offer trades. This method is triggered by the MarketEvent.OFFER_TRADED event.
+        """
         self.offers.on_trade(market_id, trade)
 
     def event_offer_split(self, *, market_id, original_offer, accepted_offer, residual_offer):

--- a/src/d3a/models/strategy/area_agents/balancing_agent.py
+++ b/src/d3a/models/strategy/area_agents/balancing_agent.py
@@ -43,13 +43,13 @@ class BalancingAgent(OneSidedAgent):
             self._trigger_balancing_trades(self.lower_market.unmatched_energy_upward,
                                            self.lower_market.unmatched_energy_downward)
 
-    def event_trade(self, *, market_id, trade):
+    def event_offer_traded(self, *, market_id, trade):
         market = self._get_market_from_market_id(market_id)
         if market is None:
             return
 
         self._calculate_and_buy_balancing_energy(market, trade)
-        super().event_trade(market_id=market_id, trade=trade)
+        super().event_offer_traded(market_id=market_id, trade=trade)
 
     def event_bid_traded(self, *, market_id, bid_trade):
         if bid_trade.already_tracked:
@@ -110,7 +110,7 @@ class BalancingAgent(OneSidedAgent):
 
     def event_balancing_trade(self, *, market_id, trade, offer=None):
         for engine in sorted(self.engines, key=lambda _: random()):
-            engine.event_trade(trade=trade)
+            engine.event_offer_traded(trade=trade)
 
     def event_balancing_offer_split(self, *, market_id, original_offer, accepted_offer,
                                     residual_offer):

--- a/src/d3a/models/strategy/area_agents/one_sided_agent.py
+++ b/src/d3a/models/strategy/area_agents/one_sided_agent.py
@@ -59,9 +59,9 @@ class OneSidedAgent(InterAreaAgent):
         for engine in sorted(self.engines, key=lambda _: random()):
             engine.tick(area=area)
 
-    def event_trade(self, *, market_id, trade):
+    def event_offer_traded(self, *, market_id, trade):
         for engine in sorted(self.engines, key=lambda _: random()):
-            engine.event_trade(trade=trade)
+            engine.event_offer_traded(trade=trade)
 
     def event_offer_deleted(self, *, market_id, offer):
         for engine in sorted(self.engines, key=lambda _: random()):

--- a/src/d3a/models/strategy/area_agents/one_sided_engine.py
+++ b/src/d3a/models/strategy/area_agents/one_sided_engine.py
@@ -137,7 +137,7 @@ class IAAEngine:
                 self.owner.log.debug(f"Forwarded offer to {self.markets.source.name} "
                                      f"{self.owner.name}, {self.name} {forwarded_offer}")
 
-    def event_trade(self, *, trade):
+    def event_offer_traded(self, *, trade):
         offer_info = self.forwarded_offers.get(trade.offer_bid.id)
         if not offer_info:
             # Trade doesn't concern us

--- a/src/d3a/models/strategy/external_strategies/__init__.py
+++ b/src/d3a/models/strategy/external_strategies/__init__.py
@@ -354,8 +354,8 @@ class ExternalMixin:
         if self.connected or self.is_aggregator_controlled:
             self._publish_trade_event(bid_trade, True)
 
-    def event_trade(self, market_id, trade):
-        super().event_trade(market_id=market_id, trade=trade)
+    def event_offer_traded(self, market_id, trade):
+        super().event_offer_traded(market_id=market_id, trade=trade)
         if self.connected or self.is_aggregator_controlled:
             self._publish_trade_event(trade, False)
 

--- a/src/d3a/models/strategy/finite_power_plant.py
+++ b/src/d3a/models/strategy/finite_power_plant.py
@@ -36,7 +36,7 @@ class FinitePowerPlant(CommercialStrategy):
         self.max_available_power_kW = \
             read_arbitrary_profile(InputProfileTypes.IDENTITY, self.max_available_power_kW)
 
-    def event_trade(self, *, market_id, trade):
+    def event_offer_traded(self, *, market_id, trade):
         # Disable offering more energy than the initial offer, in order to adhere to the max
         # available power.
         pass

--- a/src/d3a/models/strategy/load_hours.py
+++ b/src/d3a/models/strategy/load_hours.py
@@ -399,13 +399,13 @@ class LoadHoursStrategy(BidEnabledStrategy):
             if self.hrs_per_day != {} and market_day in self.hrs_per_day:
                 self.hrs_per_day[market_day] -= self._operating_hours(bid_trade.offer_bid.energy)
 
-    def event_trade(self, *, market_id, trade):
+    def event_offer_traded(self, *, market_id, trade):
         """Register the offer traded by the device and its effects. Extends the superclass method.
 
-        This method is triggered by the MarketEvent.TRADE event.
+        This method is triggered by the MarketEvent.OFFER_TRADED event.
         """
         # settlement market event_trade has to be triggered before the early return:
-        self._settlement_market_strategy.event_trade(self, market_id, trade)
+        self._settlement_market_strategy.event_offer_traded(self, market_id, trade)
 
         market = self.area.get_future_market_from_id(market_id)
         if not market:
@@ -416,7 +416,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
         if ConstSettings.BalancingSettings.FLEXIBLE_LOADS_SUPPORT:
             # Load can only put supply_balancing_offers only when there is a trade in spot_market
             self._supply_balancing_offer(market, trade)
-        super().event_trade(market_id=market_id, trade=trade)
+        super().event_offer_traded(market_id=market_id, trade=trade)
 
     # committing to increase its consumption when required
     def _demand_balancing_offer(self, market):

--- a/src/d3a/models/strategy/pv.py
+++ b/src/d3a/models/strategy/pv.py
@@ -297,9 +297,9 @@ class PVStrategy(BidEnabledStrategy):
             except MarketException:
                 pass
 
-    def event_trade(self, *, market_id, trade):
-        super().event_trade(market_id=market_id, trade=trade)
-        self._settlement_market_strategy.event_trade(self, market_id, trade)
+    def event_offer_traded(self, *, market_id, trade):
+        super().event_offer_traded(market_id=market_id, trade=trade)
+        self._settlement_market_strategy.event_offer_traded(self, market_id, trade)
         market = self.area.get_future_market_from_id(market_id)
         if market is None:
             return

--- a/src/d3a/models/strategy/settlement/strategy.py
+++ b/src/d3a/models/strategy/settlement/strategy.py
@@ -58,7 +58,7 @@ class SettlementMarketStrategyInterface:
     def event_bid_traded(self, strategy, market_id, bid_trade):
         pass
 
-    def event_trade(self, strategy, market_id, trade):
+    def event_offer_traded(self, strategy, market_id, trade):
         pass
 
 
@@ -179,7 +179,8 @@ class SettlementMarketStrategy(SettlementMarketStrategyInterface):
             strategy.state.decrement_unsettled_deviation(
                 bid_trade.offer_bid.energy, market.time_slot)
 
-    def event_trade(self, strategy: BidEnabledStrategy, market_id: str, trade: Trade) -> None:
+    def event_offer_traded(self, strategy: BidEnabledStrategy,
+                           market_id: str, trade: Trade) -> None:
         """
         Updates the unsettled deviation with the traded energy from the market
         Args:

--- a/src/d3a/models/strategy/smart_meter.py
+++ b/src/d3a/models/strategy/smart_meter.py
@@ -239,10 +239,10 @@ class SmartMeterStrategy(BidEnabledStrategy):
         self._event_tick_consumption()
         self._event_tick_production()
 
-    def event_trade(self, *, market_id, trade):
+    def event_offer_traded(self, *, market_id, trade):
         """Validate the trade for both offers and bids. Extends the superclass method.
 
-        This method is triggered by the MarketEvent.TRADE event.
+        This method is triggered by the MarketEvent.OFFER_TRADED event.
         """
         market = self.area.get_future_market_from_id(market_id)
         if not market:
@@ -251,7 +251,7 @@ class SmartMeterStrategy(BidEnabledStrategy):
         if self.owner.name not in (trade.seller, trade.buyer):
             return  # Only react to trades in which the device took part
 
-        super().event_trade(market_id=market_id, trade=trade)
+        super().event_offer_traded(market_id=market_id, trade=trade)
 
         is_buyer = self.owner.name == trade.buyer
         if is_buyer:

--- a/src/d3a/models/strategy/storage.py
+++ b/src/d3a/models/strategy/storage.py
@@ -372,9 +372,9 @@ class StorageStrategy(BidEnabledStrategy):
             for market in self.area.all_markets:
                 self.buy_energy(market)
 
-    def event_trade(self, *, market_id, trade):
+    def event_offer_traded(self, *, market_id, trade):
         market = self.area.get_future_market_from_id(market_id)
-        super().event_trade(market_id=market_id, trade=trade)
+        super().event_offer_traded(market_id=market_id, trade=trade)
 
         self.assert_if_trade_bid_price_is_too_high(market, trade)
         self.assert_if_trade_offer_price_is_too_low(market_id, trade)

--- a/tests/area/test_area.py
+++ b/tests/area/test_area.py
@@ -208,7 +208,7 @@ class TestEventDispatcher(unittest.TestCase):
         return area
 
     @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.TRADE, ),
+                           (MarketEvent.OFFER_TRADED,),
                            (MarketEvent.OFFER_SPLIT, ),
                            (MarketEvent.BID_TRADED, ),
                            (MarketEvent.BID_DELETED, ),
@@ -223,7 +223,7 @@ class TestEventDispatcher(unittest.TestCase):
         assert area.strategy.event_listener.call_count == 1
 
     @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.TRADE, ),
+                           (MarketEvent.OFFER_TRADED,),
                            (MarketEvent.OFFER_SPLIT, ),
                            (MarketEvent.BID_TRADED, ),
                            (MarketEvent.BID_DELETED, ),
@@ -236,7 +236,7 @@ class TestEventDispatcher(unittest.TestCase):
         assert area.strategy.event_listener.call_count == 0
 
     @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.TRADE, ),
+                           (MarketEvent.OFFER_TRADED,),
                            (MarketEvent.OFFER_SPLIT, ),
                            (MarketEvent.BID_TRADED, ),
                            (MarketEvent.BID_DELETED, ),

--- a/tests/strategies/external/test_init.py
+++ b/tests/strategies/external/test_init.py
@@ -244,7 +244,8 @@ class TestExternalMixin:
                           "test_area", "parent_area", fee_price=0.23, buyer_id=self.area.uuid,
                           seller_id=self.parent.uuid)
 
-        strategy.event_trade(market_id="test_market", trade=trade)
+        strategy.event_offer_traded(market_id="test_market", trade=trade)
+        print(strategy.redis.aggregator.add_batch_trade_event.call_args_list)
         assert strategy.redis.aggregator.add_batch_trade_event.call_args_list[0][0][0] == \
             self.area.uuid
 
@@ -291,7 +292,7 @@ class TestExternalMixin:
         current_time = now()
         trade = Trade("id", current_time, Offer("offer_id", now(), 20, 1.0, "test_area"),
                       "test_area", "parent_area", fee_price=0.23)
-        strategy.event_trade(market_id="test_market", trade=trade)
+        strategy.event_offer_traded(market_id="test_market", trade=trade)
         assert strategy.redis.publish_json.call_args_list[0][0][0] == "test_area/events/trade"
         call_args = strategy.redis.publish_json.call_args_list[0][0][1]
         assert call_args["trade_id"] == trade.id
@@ -327,13 +328,13 @@ class TestExternalMixin:
             skipped_trade = (
                 Trade("id", current_time, bid, "test_area", "parent_area", fee_price=0.23))
 
-            strategy.event_trade(market_id=market.id, trade=skipped_trade)
+            strategy.event_offer_traded(market_id=market.id, trade=skipped_trade)
             call_args = strategy.redis.aggregator.add_batch_trade_event.call_args_list
             assert call_args == []
 
             published_trade = (
                 Trade("id", current_time, bid, "parent_area", "test_area", fee_price=0.23))
-            strategy.event_trade(market_id=market.id, trade=published_trade)
+            strategy.event_offer_traded(market_id=market.id, trade=published_trade)
             assert strategy.redis.aggregator.add_batch_trade_event.call_args_list[0][0][0] == \
                 self.area.uuid
         else:
@@ -343,13 +344,13 @@ class TestExternalMixin:
                 Trade("id", current_time, offer, "parent_area", "test_area", fee_price=0.23))
             strategy.offers.sold_offer(offer, market.id)
 
-            strategy.event_trade(market_id=market.id, trade=skipped_trade)
+            strategy.event_offer_traded(market_id=market.id, trade=skipped_trade)
             call_args = strategy.redis.aggregator.add_batch_trade_event.call_args_list
             assert call_args == []
 
             published_trade = (
                 Trade("id", current_time, offer, "test_area", "parent_area", fee_price=0.23))
-            strategy.event_trade(market_id=market.id, trade=published_trade)
+            strategy.event_offer_traded(market_id=market.id, trade=published_trade)
             assert strategy.redis.aggregator.add_batch_trade_event.call_args_list[0][0][0] == \
                 self.area.uuid
 

--- a/tests/strategies/settlement/test_settlement_strategy.py
+++ b/tests/strategies/settlement/test_settlement_strategy.py
@@ -133,7 +133,7 @@ class TestSettlementMarketStrategy:
         self._setup_strategy_fixture(strategy_fixture, False, True)
         strategy_fixture.state.set_energy_measurement_kWh(10, self.time_slot)
         self.settlement_strategy.event_market_cycle(strategy_fixture)
-        self.settlement_strategy.event_trade(
+        self.settlement_strategy.event_offer_traded(
             strategy_fixture, self.market_mock.id,
             Trade("456", self.time_slot, self.test_offer, self.area_mock.name, self.area_mock.name)
         )

--- a/tests/test_balancing_agent.py
+++ b/tests/test_balancing_agent.py
@@ -92,8 +92,8 @@ def test_baa_event_trade(baa):
                   'IAA owner')
     fake_spot_market = FakeMarket([])
     fake_spot_market.set_time_slot(baa.lower_market.time_slot)
-    baa.event_trade(trade=trade,
-                    market_id=fake_spot_market.id)
+    baa.event_offer_traded(trade=trade,
+                           market_id=fake_spot_market.id)
     assert baa.lower_market.unmatched_energy_upward == 0
     assert baa.lower_market.unmatched_energy_downward == 0
 
@@ -117,7 +117,7 @@ def test_baa_unmatched_event_trade(baa2):
     fake_spot_market = FakeMarket([])
     fake_spot_market.set_time_slot(baa2.lower_market.time_slot)
     baa2.owner._fake_spot_market = fake_spot_market
-    baa2.event_trade(trade=trade,
-                     market_id=fake_spot_market.id)
+    baa2.event_offer_traded(trade=trade,
+                            market_id=fake_spot_market.id)
     assert baa2.lower_market.unmatched_energy_upward != 0
     assert baa2.lower_market.unmatched_energy_downward != 0

--- a/tests/test_inter_area_agent.py
+++ b/tests/test_inter_area_agent.py
@@ -569,22 +569,22 @@ class TestIAAOffer:
 
     def test_iaa_event_trade_deletes_forwarded_offer_when_sold(self, iaa, called):
         iaa.lower_market.delete_offer = called
-        iaa.event_trade(trade=Trade('trade_id',
-                                    pendulum.now(tz=TIME_ZONE),
-                                    iaa.higher_market.offers['id3'],
-                                    'owner',
-                                    'someone_else'),
-                        market_id=iaa.higher_market.id)
+        iaa.event_offer_traded(trade=Trade('trade_id',
+                                           pendulum.now(tz=TIME_ZONE),
+                                           iaa.higher_market.offers['id3'],
+                                           'owner',
+                                           'someone_else'),
+                               market_id=iaa.higher_market.id)
         assert len(iaa.lower_market.delete_offer.calls) == 1
 
     def test_iaa_event_trade_buys_accepted_offer(self, iaa2):
-        iaa2.event_trade(trade=Trade('trade_id',
-                                     pendulum.now(tz=TIME_ZONE),
-                                     iaa2.higher_market.forwarded_offer,
-                                     'owner',
-                                     'someone_else',
-                                     fee_price=0.0),
-                         market_id=iaa2.higher_market.id)
+        iaa2.event_offer_traded(trade=Trade('trade_id',
+                                            pendulum.now(tz=TIME_ZONE),
+                                            iaa2.higher_market.forwarded_offer,
+                                            'owner',
+                                            'someone_else',
+                                            fee_price=0.0),
+                                market_id=iaa2.higher_market.id)
         assert len(iaa2.lower_market.calls_energy) == 1
 
     def test_iaa_event_trade_buys_partial_accepted_offer(self, iaa2):
@@ -592,14 +592,14 @@ class TestIAAOffer:
         accepted_offer = Offer(
             total_offer.id, total_offer.time, total_offer.price, 1, total_offer.seller
         )
-        iaa2.event_trade(trade=Trade('trade_id',
-                                     pendulum.now(tz=TIME_ZONE),
-                                     accepted_offer,
-                                     'owner',
-                                     'someone_else',
-                                     'residual_offer',
-                                     fee_price=0.0),
-                         market_id=iaa2.higher_market.id)
+        iaa2.event_offer_traded(trade=Trade('trade_id',
+                                            pendulum.now(tz=TIME_ZONE),
+                                            accepted_offer,
+                                            'owner',
+                                            'someone_else',
+                                            'residual_offer',
+                                            fee_price=0.0),
+                                market_id=iaa2.higher_market.id)
         assert iaa2.lower_market.calls_energy[0] == 1
 
     def test_iaa_event_offer_split_and_trade_correctly_populate_forwarded_offer_entries(
@@ -627,14 +627,14 @@ class TestIAAOffer:
         # and the residual offer was added
         assert engine.forwarded_offers[residual_offer_id].target_offer.energy == accepted.energy
 
-        iaa2.event_trade(trade=Trade('trade_id',
-                                     pendulum.now(tz=TIME_ZONE),
-                                     accepted,
-                                     'owner',
-                                     'someone_else',
-                                     residual,
-                                     fee_price=0.0),
-                         market_id=iaa2.lower_market.id)
+        iaa2.event_offer_traded(trade=Trade('trade_id',
+                                            pendulum.now(tz=TIME_ZONE),
+                                            accepted,
+                                            'owner',
+                                            'someone_else',
+                                            residual,
+                                            fee_price=0.0),
+                                market_id=iaa2.lower_market.id)
 
         # after the trade event:
         # the forwarded_offers only contain the residual offer

--- a/tests/test_redis_communication.py
+++ b/tests/test_redis_communication.py
@@ -138,7 +138,7 @@ class TestRedisMarketEventDispatcher(unittest.TestCase):
                          children=[self.device1, self.device2])
         self.area.dispatcher.market_event_dispatcher.redis = MagicMock(spec=RedisCommunicator)
         self.area.dispatcher.market_event_dispatcher.child_response_events = {
-            MarketEvent.TRADE.value: MagicMock(spec=Event),
+            MarketEvent.OFFER_TRADED.value: MagicMock(spec=Event),
             MarketEvent.OFFER.value: MagicMock(spec=Event),
             MarketEvent.OFFER_DELETED.value: MagicMock(spec=Event),
             MarketEvent.OFFER_SPLIT.value: MagicMock(spec=Event),
@@ -146,7 +146,7 @@ class TestRedisMarketEventDispatcher(unittest.TestCase):
         self.device1.dispatcher.market_event_dispatcher.redis = MagicMock(
             spec=RedisCommunicator)
         self.device1.dispatcher.market_event_dispatcher.child_response_events = {
-            MarketEvent.TRADE.value: MagicMock(spec=Event),
+            MarketEvent.OFFER_TRADED.value: MagicMock(spec=Event),
             MarketEvent.OFFER.value: MagicMock(spec=Event),
             MarketEvent.OFFER_DELETED.value: MagicMock(spec=Event),
             MarketEvent.OFFER_SPLIT.value: MagicMock(spec=Event),
@@ -154,7 +154,7 @@ class TestRedisMarketEventDispatcher(unittest.TestCase):
         self.device2.dispatcher.market_event_dispatcher.redis = MagicMock(
             spec=RedisCommunicator)
         self.device2.dispatcher.market_event_dispatcher.child_response_events = {
-            MarketEvent.TRADE.value: MagicMock(spec=Event),
+            MarketEvent.OFFER_TRADED.value: MagicMock(spec=Event),
             MarketEvent.OFFER.value: MagicMock(spec=Event),
             MarketEvent.OFFER_DELETED.value: MagicMock(spec=Event),
             MarketEvent.OFFER_SPLIT.value: MagicMock(spec=Event),
@@ -184,7 +184,7 @@ class TestRedisMarketEventDispatcher(unittest.TestCase):
             self.area.dispatcher.market_event_dispatcher.response_callback)
 
     @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.TRADE, ),
+                           (MarketEvent.OFFER_TRADED,),
                            (MarketEvent.OFFER_SPLIT, ),
                            (MarketEvent.OFFER_DELETED, )])
     def test_publish_response(self, market_event):
@@ -197,7 +197,7 @@ class TestRedisMarketEventDispatcher(unittest.TestCase):
             dispatcher.redis.publish.assert_any_call(response_channel, response_payload)
 
     @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.TRADE, ),
+                           (MarketEvent.OFFER_TRADED,),
                            (MarketEvent.OFFER_SPLIT, ),
                            (MarketEvent.OFFER_DELETED, )])
     def tests_broadcast(self, market_event):
@@ -214,7 +214,7 @@ class TestRedisMarketEventDispatcher(unittest.TestCase):
                 clear.call_count == len(self.area.children)
 
     @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.TRADE, ),
+                           (MarketEvent.OFFER_TRADED,),
                            (MarketEvent.OFFER_SPLIT, ),
                            (MarketEvent.OFFER_DELETED, )])
     def test_response_callback_from_children_unblocks_thread_event(self, market_event):
@@ -238,7 +238,7 @@ class TestRedisMarketEventDispatcher(unittest.TestCase):
                 evt.set.assert_not_called()
 
     @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.TRADE, ),
+                           (MarketEvent.OFFER_TRADED,),
                            (MarketEvent.OFFER_SPLIT, ),
                            (MarketEvent.OFFER_DELETED, )])
     def test_event_listener_calls_the_event_listener_of_the_root_dispatcher(self, market_event):

--- a/tests/test_strategy_commercial_producer.py
+++ b/tests/test_strategy_commercial_producer.py
@@ -203,14 +203,13 @@ def test_event_trade(area_test2, commercial_test2):
     commercial_test2.event_activate()
     commercial_test2.event_market_cycle()
     traded_offer = Offer(id="id", time=pendulum.now(), price=20, energy=1, seller="FakeArea",)
-    commercial_test2.event_trade(market_id=area_test2.test_market.id,
-                                 trade=Trade(id="id",
-                                             time="time",
-                                             offer_bid=traded_offer,
-                                             seller="FakeArea",
-                                             buyer="buyer"
-                                             )
-                                 )
+    commercial_test2.event_offer_traded(market_id=area_test2.test_market.id,
+                                        trade=Trade(id="id",
+                                                    time="time",
+                                                    offer_bid=traded_offer,
+                                                    seller="FakeArea",
+                                                    buyer="buyer")
+                                        )
     assert len(area_test2.test_market.created_offers) == 1
     assert area_test2.test_market.created_offers[-1].energy == sys.maxsize
 
@@ -245,13 +244,13 @@ def test_event_trade_after_offer_changed_partial_offer(area_test2, commercial_te
                                        residual_offer=residual_offer)
     assert original_offer.id in commercial_test2.offers.split
     assert commercial_test2.offers.split[original_offer.id] == accepted_offer
-    commercial_test2.event_trade(market_id=area_test2.test_market.id,
-                                 trade=Trade(id="id",
-                                             time="time",
-                                             offer_bid=original_offer,
-                                             seller="FakeArea",
-                                             buyer="buyer")
-                                 )
+    commercial_test2.event_offer_traded(market_id=area_test2.test_market.id,
+                                        trade=Trade(id="id",
+                                                    time="time",
+                                                    offer_bid=original_offer,
+                                                    seller="FakeArea",
+                                                    buyer="buyer")
+                                        )
 
     assert residual_offer in commercial_test2.offers.posted
     assert commercial_test2.offers.posted[residual_offer] == area_test2.test_market.id

--- a/tests/test_strategy_infinite_bus.py
+++ b/tests/test_strategy_infinite_bus.py
@@ -239,13 +239,14 @@ def test_event_trade(area_test2, bus_test2):
     bus_test2.event_activate()
     bus_test2.event_market_cycle()
     traded_offer = Offer(id="id", time=pendulum.now(), price=20, energy=1, seller="FakeArea",)
-    bus_test2.event_trade(market_id=area_test2.test_market.id, trade=Trade(id="id",
-                                                                           time="time",
-                                                                           offer_bid=traded_offer,
-                                                                           seller="FakeArea",
-                                                                           buyer="buyer"
-                                                                           )
-                          )
+    bus_test2.event_offer_traded(market_id=area_test2.test_market.id,
+                                 trade=Trade(id="id",
+                                             time="time",
+                                             offer_bid=traded_offer,
+                                             seller="FakeArea",
+                                             buyer="buyer"
+                                             )
+                                 )
     assert len(area_test2.test_market.created_offers) == 1
     assert area_test2.test_market.created_offers[-1].energy == sys.maxsize
 
@@ -278,13 +279,13 @@ def test_event_trade_after_offer_changed_partial_offer(area_test2, bus_test2):
                                 residual_offer=residual_offer)
     assert original_offer.id in bus_test2.offers.split
     assert bus_test2.offers.split[original_offer.id] == accepted_offer
-    bus_test2.event_trade(market_id=area_test2.test_market.id,
-                          trade=Trade(id="id",
-                                      time="time",
-                                      offer_bid=original_offer,
-                                      seller="FakeArea",
-                                      buyer="buyer")
-                          )
+    bus_test2.event_offer_traded(market_id=area_test2.test_market.id,
+                                 trade=Trade(id="id",
+                                             time="time",
+                                             offer_bid=original_offer,
+                                             seller="FakeArea",
+                                             buyer="buyer")
+                                 )
 
     assert residual_offer in bus_test2.offers.posted
     assert bus_test2.offers.posted[residual_offer] == area_test2.test_market.id

--- a/tests/test_strategy_load_hours.py
+++ b/tests/test_strategy_load_hours.py
@@ -479,12 +479,13 @@ def test_balancing_offers_are_created_if_device_in_registry(
     selected_offer = area_test2.current_market.sorted_offers[0]
     balancing_fixture.state._energy_requirement_Wh[area_test2.current_market.time_slot] = \
         selected_offer.energy * 1000.0
-    balancing_fixture.event_trade(market_id=area_test2.current_market.id,
-                                  trade=Trade(id='id',
-                                              time=area_test2.now,
-                                              offer_bid=selected_offer,
-                                              seller='B',
-                                              buyer='FakeArea'))
+    balancing_fixture.event_offer_traded(market_id=area_test2.current_market.id,
+                                         trade=Trade(id='id',
+                                                     time=area_test2.now,
+                                                     offer_bid=selected_offer,
+                                                     seller='B',
+                                                     buyer='FakeArea')
+                                         )
     assert len(area_test2.test_balancing_market.created_balancing_offers) == 2
     actual_balancing_supply_energy = \
         area_test2.test_balancing_market.created_balancing_offers[1].energy
@@ -574,7 +575,7 @@ def test_assert_if_trade_rate_is_higher_than_bid_rate(load_hours_strategy_test3)
     trade = Trade("trade_id", "time", expensive_bid, load_hours_strategy_test3, "buyer")
 
     with pytest.raises(AssertionError):
-        load_hours_strategy_test3.event_trade(market_id=market_id, trade=trade)
+        load_hours_strategy_test3.event_offer_traded(market_id=market_id, trade=trade)
 
 
 def test_update_state(load_hours_strategy_test1):

--- a/tests/test_strategy_pv.py
+++ b/tests/test_strategy_pv.py
@@ -279,13 +279,12 @@ def pv_test4(area_test3, called):
 
 def testing_event_trade(area_test3, pv_test4):
     pv_test4.state._available_energy_kWh[area_test3.test_market.time_slot] = 1
-    pv_test4.event_trade(market_id=area_test3.test_market.id,
-                         trade=Trade(id="id", time="time",
-                                     offer_bid=Offer(id="id", time=pendulum.now(), price=20,
-                                                     energy=1, seller="FakeArea"),
-                                     seller=area_test3.name, buyer="buyer"
-                                     )
-                         )
+    pv_test4.event_offer_traded(market_id=area_test3.test_market.id,
+                                trade=Trade(id="id", time="time",
+                                            offer_bid=Offer(id="id", time=pendulum.now(), price=20,
+                                                            energy=1, seller="FakeArea"),
+                                            seller=area_test3.name, buyer="buyer")
+                                )
     assert len(pv_test4.offers.open) == 0
 
 
@@ -391,7 +390,7 @@ def test_does_not_offer_sold_energy_again(pv_test6, market_test3):
         pv_test6.state._energy_production_forecast_kWh[TIME]
     fake_trade = FakeTrade(market_test3.created_offers[0])
     fake_trade.seller = pv_test6.owner.name
-    pv_test6.event_trade(market_id=market_test3.id, trade=fake_trade)
+    pv_test6.event_offer_traded(market_id=market_test3.id, trade=fake_trade)
     market_test3.created_offers = []
     assert not market_test3.created_offers
 
@@ -554,7 +553,7 @@ def test_assert_if_trade_rate_is_lower_than_offer_rate(pv_test11):
     trade = Trade("trade_id", "time", to_cheap_offer, pv_test11, "buyer")
 
     with pytest.raises(AssertionError):
-        pv_test11.event_trade(market_id=market_id, trade=trade)
+        pv_test11.event_offer_traded(market_id=market_id, trade=trade)
 
 
 @pytest.fixture(name="pv_strategy")

--- a/tests/test_strategy_pvpredefined.py
+++ b/tests/test_strategy_pvpredefined.py
@@ -325,7 +325,7 @@ def test_does_not_offer_sold_energy_again(pv_test6, market_test3):
         pv_test6.state._energy_production_forecast_kWh[TIME]
     fake_trade = FakeTrade(market_test3.created_offers[0])
     fake_trade.seller = pv_test6.owner.name
-    pv_test6.event_trade(market_id=market_test3.id, trade=fake_trade)
+    pv_test6.event_offer_traded(market_id=market_test3.id, trade=fake_trade)
     market_test3.created_offers = []
     pv_test6.event_tick()
     assert not market_test3.created_offers

--- a/tests/test_strategy_storage.py
+++ b/tests/test_strategy_storage.py
@@ -384,7 +384,7 @@ def test_if_trades_are_handled_correctly(storage_strategy_test6, market_test6):
         lambda _id: market_test6 if _id == market_test6.id else None)
     storage_strategy_test6.state.add_default_values_to_state_profiles(
         [storage_strategy_test6.spot_market_time_slot])
-    storage_strategy_test6.event_trade(market_id=market_test6.id, trade=market_test6.trade)
+    storage_strategy_test6.event_offer_traded(market_id=market_test6.id, trade=market_test6.trade)
     assert (market_test6.trade.offer_bid in
             storage_strategy_test6.offers.sold[market_test6.id])
     assert market_test6.trade.offer_bid not in storage_strategy_test6.offers.open
@@ -710,7 +710,8 @@ def storage_strategy_test13(area_test13, called):
 def test_storage_event_trade(storage_strategy_test11, market_test13):
     storage_strategy_test11.state.add_default_values_to_state_profiles(
         [storage_strategy_test11.spot_market_time_slot])
-    storage_strategy_test11.event_trade(market_id=market_test13.id, trade=market_test13.trade)
+    storage_strategy_test11.event_offer_traded(market_id=market_test13.id,
+                                               trade=market_test13.trade)
     assert storage_strategy_test11.state.pledged_sell_kWh[market_test13.time_slot] == \
         market_test13.trade.offer_bid.energy
     assert storage_strategy_test11.state.offered_sell_kWh[
@@ -829,8 +830,9 @@ def test_energy_origin(storage_strategy_test15, market_test15):
     storage_strategy_test15.area.current_market.trade = \
         Trade('id', 'time', Offer('id', now(), 20, 1.0, 'OtherChildArea'),
               'OtherChildArea', 'Storage')
-    storage_strategy_test15.event_trade(market_id=market_test15.id,
-                                        trade=storage_strategy_test15.area.current_market.trade)
+    storage_strategy_test15.event_offer_traded(
+        market_id=market_test15.id,
+        trade=storage_strategy_test15.area.current_market.trade)
     assert len(storage_strategy_test15.state.get_used_storage_share) == 2
     assert storage_strategy_test15.state.get_used_storage_share == [EnergyOrigin(
         ESSEnergyOrigin.EXTERNAL, 15), EnergyOrigin(ESSEnergyOrigin.LOCAL, 1)]
@@ -838,8 +840,9 @@ def test_energy_origin(storage_strategy_test15, market_test15):
     storage_strategy_test15.area.current_market.trade = \
         Trade('id', 'time', Offer('id', now(), 20, 2.0, 'Storage'),
               'Storage', 'A')
-    storage_strategy_test15.event_trade(market_id=market_test15.id,
-                                        trade=storage_strategy_test15.area.current_market.trade)
+    storage_strategy_test15.event_offer_traded(
+        market_id=market_test15.id,
+        trade=storage_strategy_test15.area.current_market.trade)
     assert len(storage_strategy_test15.state.get_used_storage_share) == 2
     assert storage_strategy_test15.state.get_used_storage_share == [EnergyOrigin(
         ESSEnergyOrigin.EXTERNAL, 13), EnergyOrigin(ESSEnergyOrigin.LOCAL, 1)]
@@ -847,8 +850,9 @@ def test_energy_origin(storage_strategy_test15, market_test15):
     storage_strategy_test15.area.current_market.trade = \
         Trade('id', 'time', Offer('id', now(), 20, 1.0, 'FakeArea'),
               'FakeArea', 'Storage')
-    storage_strategy_test15.event_trade(market_id=market_test15.id,
-                                        trade=storage_strategy_test15.area.current_market.trade)
+    storage_strategy_test15.event_offer_traded(
+        market_id=market_test15.id,
+        trade=storage_strategy_test15.area.current_market.trade)
     assert len(storage_strategy_test15.state.get_used_storage_share) == 3
     assert storage_strategy_test15.state.get_used_storage_share == [EnergyOrigin(
         ESSEnergyOrigin.EXTERNAL, 13.0), EnergyOrigin(ESSEnergyOrigin.LOCAL, 1.0),
@@ -884,7 +888,7 @@ def test_assert_if_trade_rate_is_lower_than_offer_rate(storage_test11):
     trade = Trade("trade_id", "time", to_cheap_offer, storage_test11, "buyer")
 
     with pytest.raises(AssertionError):
-        storage_test11.event_trade(market_id=market_id, trade=trade)
+        storage_test11.event_offer_traded(market_id=market_id, trade=trade)
 
 
 def test_assert_if_trade_rate_is_higher_than_bid_rate(storage_test11):
@@ -895,4 +899,4 @@ def test_assert_if_trade_rate_is_higher_than_bid_rate(storage_test11):
     trade = Trade("trade_id", "time", expensive_bid, storage_test11, "buyer")
 
     with pytest.raises(AssertionError):
-        storage_test11.event_trade(market_id=market_id, trade=trade)
+        storage_test11.event_offer_traded(market_id=market_id, trade=trade)


### PR DESCRIPTION
…r_traded' and 'Events.Trade' into 'Events.OFFER_TRADED' in order to be consistent with the bid trade.