### PR TITLE
Rename old d3a-blockchain references to gsy-dex

### DIFF
--- a/requirements/blockchain.in
+++ b/requirements/blockchain.in
@@ -1,3 +1,3 @@
 -r base.txt
 
--e git+https://github.com/gridsingularity/d3a-blockchain@master#egg=d3a_blockchain
+-e git+https://github.com/gridsingularity/gsy-dex@master#egg=gsy_dex

--- a/requirements/blockchain.txt
+++ b/requirements/blockchain.txt
@@ -4,14 +4,14 @@
 #
 #    pip-compile --max-rounds=100 --no-emit-index-url requirements/blockchain.in
 #
--e git+https://github.com/gridsingularity/d3a-blockchain@master#egg=d3a_blockchain
+-e git+https://github.com/gridsingularity/gsy-dex@master#egg=gsy_dex
     # via -r requirements/blockchain.in
 -e git+https://github.com/gridsingularity/gsy-framework@master#egg=gsy_framework
     # via -r requirements/base.txt
 attrs==21.2.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   jsonschema
 awesome-slugify==1.6.5
@@ -19,12 +19,12 @@ awesome-slugify==1.6.5
 backports.entry-points-selectable==1.1.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   virtualenv
 base58==2.0.1
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   scalecodec
     #   substrate-interface
 cached-property==1.5.2
@@ -32,20 +32,20 @@ cached-property==1.5.2
 certifi==2021.10.8
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   requests
     #   substrate-interface
 cfgv==3.3.1
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pre-commit
 chardet==4.0.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   requests
 click==8.0.3
@@ -60,70 +60,70 @@ colorlog==4.7.2
 distlib==0.3.3
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   virtualenv
 entrypoints==0.3
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
     #   flake8
+    #   gsy-dex
     #   gsy-framework
 filelock==3.3.2
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   tox
     #   virtualenv
 flake8==3.7.9
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
     #   flake8-tuple
+    #   gsy-dex
     #   gsy-framework
 flake8-tuple==0.4.1
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 identify==2.3.3
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pre-commit
 idna==2.10
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   requests
     #   substrate-interface
 jsonschema==4.1.2
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 kafka-python==2.0.2
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 mccabe==0.6.1
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
     #   flake8
+    #   gsy-dex
     #   gsy-framework
 more-itertools==8.8.0
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   scalecodec
 nodeenv==1.6.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pre-commit
 numpy==1.20.3
@@ -131,18 +131,18 @@ numpy==1.20.3
 packaging==21.2
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   tox
 pendulum==2.1.2
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 platformdirs==2.4.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   virtualenv
 plotly==5.3.1
@@ -150,7 +150,7 @@ plotly==5.3.1
 pluggy==1.0.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   tox
 pony==0.7.14
@@ -158,54 +158,54 @@ pony==0.7.14
 pre-commit==2.15.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 py==1.10.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   tox
 py-bip39-bindings==0.1.7
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   substrate-interface
 py-ed25519-bindings==0.1.3
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   substrate-interface
 py-sr25519-bindings==0.1.3
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   substrate-interface
 pycodestyle==2.5.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
     #   flake8
+    #   gsy-dex
     #   gsy-framework
 pyflakes==2.1.1
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
     #   flake8
+    #   gsy-dex
     #   gsy-framework
 pyparsing==2.4.7
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   packaging
 pyrsistent==0.18.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   jsonschema
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pendulum
 python-rex==0.4
@@ -215,19 +215,19 @@ pytz==2021.3
 pytzdata==2020.1
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pendulum
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pre-commit
 redis==3.5.3
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   rq
 regex==2021.10.23
@@ -237,7 +237,7 @@ regex==2021.10.23
 requests==2.25.1
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   scalecodec
     #   substrate-interface
@@ -245,13 +245,13 @@ rq==1.10.0
     # via -r requirements/base.txt
 scalecodec==0.11.16
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   substrate-interface
 six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
     #   flake8-tuple
+    #   gsy-dex
     #   gsy-framework
     #   plotly
     #   python-dateutil
@@ -262,11 +262,11 @@ six==1.16.0
 sortedcontainers==2.4.0
     # via -r requirements/base.txt
 substrate-interface==0.13.9
-    # via d3a-blockchain
+    # via gsy-dex
 tabulate==0.8.9
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 tenacity==8.0.1
     # via
@@ -275,14 +275,14 @@ tenacity==8.0.1
 toml==0.10.2
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pre-commit
     #   tox
 tox==3.24.4
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 unidecode==0.4.21
     # via
@@ -291,26 +291,26 @@ unidecode==0.4.21
 urllib3==1.26.7
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   requests
 virtualenv==20.10.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
     #   pre-commit
     #   tox
 websocket-client==0.58.0
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   substrate-interface
 websockets==10.0
     # via
     #   -r requirements/base.txt
-    #   d3a-blockchain
+    #   gsy-dex
     #   gsy-framework
 xxhash==2.0.2
     # via
-    #   d3a-blockchain
+    #   gsy-dex
     #   substrate-interface


### PR DESCRIPTION
Fix remnant of rebranding. The old d3a-blockchain repo is now called gsy-dex.