### PR TITLE
D3ASIM-3553: Rename Area to Market

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -36,7 +36,7 @@ from gsy_e.models.strategy.storage import StorageStrategy
 
 if TYPE_CHECKING:
     from gsy_e.models.area import Area
-    from gsy_e.models.market import Market
+    from gsy_e.models.market import MarketBase
     from gsy_e.gsy_e_core.simulation import SimulationProgressInfo
 
 _NO_VALUE = {
@@ -156,7 +156,7 @@ class SimulationEndpointBuffer:
         return stats_dict
 
     @staticmethod
-    def _read_market_stats_to_dict(market: "Market") -> Dict:
+    def _read_market_stats_to_dict(market: "MarketBase") -> Dict:
         """Read all market related stats to a dictionary."""
         stats_dict = {"bids": [], "offers": [], "trades": [], "market_fee": 0.0}
         for offer in market.offer_history:

--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -237,18 +237,19 @@ class Area:
 
         self._set_grid_fees(grid_fee_constant, grid_fee_percentage)
         self.throughput = throughput
-        self._update_descendants_strategy_prices()
+        self.update_descendants_strategy_prices()
 
         return None
 
-    def _update_descendants_strategy_prices(self):
+    def update_descendants_strategy_prices(self):
+        """Recursively update the strategy prices of all descendants of the area."""
         try:
             if self.strategy is not None:
                 self.strategy.event_activate_price()
             for child in self.children:
-                child._update_descendants_strategy_prices()
+                child.update_descendants_strategy_prices()
         except Exception:
-            log.exception("area._update_descendants_strategy_prices failed.")
+            log.exception("area.update_descendants_strategy_prices failed.")
             return
 
     def _set_grid_fees(self, grid_fee_const, grid_fee_percentage):

--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -102,6 +102,10 @@ class AreaChildrenList(list):
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-public-methods
 class Area:
+    """Generic class to define both market areas and devices.
+
+    Important: this class should not be used in setup files. Please use Market or Asset instead.
+    """
 
     # pylint: disable=too-many-arguments
     def __init__(self, name: str = None, children: List["Area"] = None,
@@ -668,3 +672,17 @@ class Area:
     def is_market_future(self, market_id: str) -> bool:
         """Return True if market_id belongs to a FUTURE market."""
         return market_id == self.future_markets.id
+
+
+class Market(Area):
+    """Class to define geographical market areas that can contain children (areas or assets)."""
+
+
+class Asset(Area):
+    """Class to define assets (devices). These instances cannot contain children."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.children:
+            raise ValueError(f"{self.__class__.__name__} instances can't have children.")

--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -16,18 +16,18 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from logging import getLogger
-from typing import List, Dict, Optional, TYPE_CHECKING
+from typing import List, Dict, Optional, Union, TYPE_CHECKING
 from uuid import uuid4
 
 from gsy_framework.area_validator import validate_area
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.enums import SpotMarketTypeEnum
+from gsy_framework.exceptions import GSyAreaException, GSyDeviceException
 from gsy_framework.utils import key_in_dict_and_not_none
 from pendulum import DateTime, duration, today
 from slugify import slugify
 
 import gsy_e.constants
-from cached_property import cached_property
 from gsy_e.gsy_e_core.blockchain_interface import blockchain_interface_factory
 from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.gsy_e_core.exceptions import AreaException
@@ -40,17 +40,18 @@ from gsy_e.models.area.redis_external_market_connection import RedisMarketExtern
 from gsy_e.models.area.stats import AreaStats
 from gsy_e.models.area.throughput_parameters import ThroughputParameters
 from gsy_e.models.config import SimulationConfig
+from gsy_e.models.market.future import FutureMarkets
 from gsy_e.models.market.market_structures import AvailableMarketTypes
 from gsy_e.models.strategy import BaseStrategy
 from gsy_e.models.strategy.external_strategies import ExternalMixin
-from gsy_e.models.market.future import FutureMarkets
+
 log = getLogger(__name__)
 
-
 if TYPE_CHECKING:
-    from d3a.models.market import Market
+    from d3a.models.market import MarketBase
 
 
+# pylint: disable=fixme
 # TODO: As this is only used in the unittests, please remove it here and replace the usages
 #       of this class with gsy-framework.constants_limits.GlobalConfig class:
 DEFAULT_CONFIG = SimulationConfig(
@@ -79,6 +80,8 @@ def check_area_name_exists_in_parent_area(parent_area, name):
 
 
 class AreaChildrenList(list):
+    """Class to define the children of an area."""
+
     def __init__(self, parent_area, *args, **kwargs):
         self.parent_area = parent_area
         super().__init__(*args, **kwargs)
@@ -96,15 +99,18 @@ class AreaChildrenList(list):
         super().insert(index, item)
 
 
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-public-methods
 class Area:
 
+    # pylint: disable=too-many-arguments
     def __init__(self, name: str = None, children: List["Area"] = None,
                  uuid: str = None,
                  strategy: BaseStrategy = None,
                  config: SimulationConfig = None,
                  budget_keeper=None,
                  balancing_spot_trade_ratio=ConstSettings.BalancingSettings.SPOT_TRADE_RATIO,
-                 event_list=[],
+                 event_list=None,
                  grid_fee_percentage: float = None,
                  grid_fee_constant: float = None,
                  external_connection_available: bool = False,
@@ -130,6 +136,7 @@ class Area:
             raise AreaException("A leaf area can not have children.")
         self.strategy = strategy
         self._config = config
+        event_list = event_list if event_list is not None else []
         self.events = Events(event_list, self)
         self.budget_keeper = budget_keeper
         if budget_keeper:
@@ -148,6 +155,7 @@ class Area:
 
     @property
     def name(self):
+        """Return the name of the area."""
         return self.__name
 
     @name.setter
@@ -158,6 +166,7 @@ class Area:
         self.__name = new_name
 
     def get_state(self):
+        """Get the current state of the area."""
         state = {}
         if self.strategy is not None:
             state = self.strategy.get_state()
@@ -169,6 +178,7 @@ class Area:
         return state
 
     def restore_state(self, saved_state):
+        """Restore a previously-saved state."""
         self.current_tick = saved_state["current_tick"]
         self.stats.restore_state(saved_state["area_stats"])
         if self.strategy is not None:
@@ -221,13 +231,15 @@ class Area:
                             export_capacity_kVA=export_capacity_kVA
                         )
 
-        except Exception as ex:
+        except (GSyAreaException, GSyDeviceException) as ex:
             log.error(ex)
-            return
+            return None
 
         self._set_grid_fees(grid_fee_constant, grid_fee_percentage)
         self.throughput = throughput
         self._update_descendants_strategy_prices()
+
+        return None
 
     def _update_descendants_strategy_prices(self):
         try:
@@ -250,22 +262,27 @@ class Area:
         self.grid_fee_constant = grid_fee_const
         self.grid_fee_percentage = grid_fee_percentage
 
-    def get_path_to_root_fees(self):
+    def get_path_to_root_fees(self) -> float:
+        """Return the cumulative fees value from the current area to its root."""
         if self.parent is not None:
             grid_fee_constant = self.grid_fee_constant if self.grid_fee_constant else 0
             return grid_fee_constant + self.parent.get_path_to_root_fees()
         return self.grid_fee_constant if self.grid_fee_constant else 0
 
     def get_grid_fee(self):
-        grid_fee_type = self.config.grid_fee_type \
-            if self.config is not None \
-            else ConstSettings.IAASettings.GRID_FEE_TYPE
+        """Return the current grid fee for the area."""
+        grid_fee_type = (
+            self.config.grid_fee_type if self.config is not None
+            else ConstSettings.IAASettings.GRID_FEE_TYPE)
+
         return self.grid_fee_constant if grid_fee_type == 1 else self.grid_fee_percentage
 
     def set_events(self, event_list):
+        """Set events for the area."""
         self.events = Events(event_list, self)
 
     def activate(self, bc=None, current_tick=None, simulation_id=None):
+        """Activate the area and broadcast the activation event."""
         if current_tick is not None:
             self.current_tick = current_tick
 
@@ -301,6 +318,7 @@ class Area:
             self.redis_ext_conn.sub_to_external_channels()
 
     def deactivate(self):
+        """Deactivate the area."""
         self.cycle_markets(deactivate=True)
         if self.redis_ext_conn is not None:
             self.redis_ext_conn.deactivate()
@@ -386,6 +404,7 @@ class Area:
         self.stats.calculate_energy_deviances()
 
     def publish_market_cycle_to_external_clients(self):
+        """Recursively notify children and external clients about the market cycle event."""
         if self.strategy and isinstance(self.strategy, ExternalMixin):
             self.strategy.publish_market_cycle()
         elif not self.strategy and self.external_connection_available:
@@ -464,25 +483,28 @@ class Area:
             self.dispatcher.broadcast_tick()
 
     def __repr__(self):
-        return "<Area '{s.name}' markets: {markets}>".format(
-            s=self,
-            markets=[t.format(gsy_e.constants.TIME_FORMAT) for t in self._markets.markets.keys()]
-        )
+        return (
+            f"<Area '{self.name}' markets: "
+            f"{[t.format(gsy_e.constants.TIME_FORMAT) for t in self._markets.markets]}>")
 
     @property
     def all_markets(self):
-        return [m for m in self._markets.markets.values() if m.in_sim_duration]
+        """Return all markets that the area is involved with."""
+        return [market for market in self._markets.markets.values() if market.in_sim_duration]
 
     @property
-    def current_slot(self):
+    def current_slot(self) -> int:
+        """Return the number of the current market slot."""
         return self.current_tick // self.config.ticks_per_slot
 
     @property
     def current_tick_in_slot(self):
+        """Return the number of the current tick in the current market slot."""
         return self.current_tick % self.config.ticks_per_slot
 
     @property
-    def config(self):
+    def config(self) -> Union[SimulationConfig, GlobalConfig]:
+        """Return the configuration used by the area."""
         if self._config:
             return self._config
         if self.parent:
@@ -491,20 +513,10 @@ class Area:
 
     @property
     def bc(self):
+        """Return the blockchain interface used by the area."""
         if self._bc is not None:
             return self._bc
         return None
-
-    @cached_property
-    def child_by_slug(self):
-        slug_map = {}
-        areas = [self]
-        while areas:
-            for area in list(areas):
-                slug_map[area.slug] = area
-                areas.remove(area)
-                areas.extend(area.children)
-        return slug_map
 
     @property
     def now(self) -> DateTime:
@@ -521,28 +533,30 @@ class Area:
 
     @property
     def past_markets(self) -> List:
+        """Return the past markets of the area."""
         return list(self._markets.past_markets.values())
 
     def get_market(self, time_slot):
+        """Return the market of the area that occurred at the specified time slot."""
         return self._markets.markets.get(time_slot)
 
-    def get_past_market(self, time_slot):
-        return self._markets.past_markets[time_slot]
-
     def get_balancing_market(self, time_slot):
+        """Return the balancing market of the area that occurred at the specified time slot."""
         return self._markets.balancing_markets[time_slot]
 
     @property
     def balancing_markets(self) -> List:
+        """Return the balancing markets of the area."""
         return list(self._markets.balancing_markets.values())
 
     @property
     def past_balancing_markets(self) -> List:
+        """Return the past balancing markets of the area."""
         return list(self._markets.past_balancing_markets.values())
 
     @property
     def spot_market(self):
-        """Returns the "current" market (i.e. the one currently "running")"""
+        """Return the "current" market (i.e. the one currently "running")."""
         try:
             return self.all_markets[-1]
         except IndexError:
@@ -550,8 +564,7 @@ class Area:
 
     @property
     def current_market(self):
-        """Returns the "most recent past market" market
-        (i.e. the one that has been finished last)"""
+        """Return the "most recent past market" (the one that has been finished last)."""
         try:
             return list(self._markets.past_markets.values())[-1]
         except IndexError:
@@ -559,16 +572,17 @@ class Area:
 
     @property
     def current_balancing_market(self):
-        """Returns the "current" balancing market (i.e. the one currently "running")"""
+        """Return the "current" balancing market (i.e. the one currently "running")"""
         try:
             return list(self._markets.past_balancing_markets.values())[-1]
         except IndexError:
             return None
 
     def get_future_market_from_id(self, _id):
+        """Return the future market that corresponds to the provided ID."""
         return self._markets.indexed_future_markets.get(_id, None)
 
-    def get_spot_or_future_market_by_id(self, market_id: str) -> Optional["Market"]:
+    def get_spot_or_future_market_by_id(self, market_id: str) -> Optional["MarketBase"]:
         if self.is_market_spot(market_id):
             return self.spot_market
         if self.is_market_future(market_id):
@@ -580,6 +594,7 @@ class Area:
 
     @property
     def last_past_market(self):
+        """Return the most recent of the area's past markets."""
         try:
             return list(self._markets.past_markets.values())[-1]
         except IndexError:
@@ -587,18 +602,22 @@ class Area:
 
     @property
     def future_market_time_slots(self) -> List[DateTime]:
+        """Return the future markets time slots of the area."""
         return self._markets.future_markets.market_time_slots
 
     @property
     def future_markets(self) -> FutureMarkets:
+        """Return the future markets of the area."""
         return self._markets.future_markets
 
     @property
     def settlement_markets(self) -> Dict:
+        """Return the settlement markets of the area."""
         return self._markets.settlement_markets
 
     @property
     def last_past_settlement_market(self):
+        """Return the most recent of the area's past settlement markets."""
         try:
             return list(self._markets.past_settlement_markets.items())[-1]
         except IndexError:
@@ -606,9 +625,11 @@ class Area:
 
     @property
     def past_settlement_markets(self) -> Dict:
+        """Return the past settlement markets of the area."""
         return self._markets.past_settlement_markets
 
     def get_settlement_market(self, time_slot):
+        """Return the settlement market of the area that occurred at the specified time slot."""
         return self._markets.settlement_markets.get(time_slot)
 
     def get_market_instances_from_class_type(self, market_type: AvailableMarketTypes) -> Dict:
@@ -618,11 +639,11 @@ class Area:
             market_type: Selected market type (spot/balancing/settlement/future)
 
         Returns: Dicts with market objects for the selected market type
-
         """
         return self._markets.get_market_instances_from_class_type(market_type)
 
     def update_config(self, **kwargs):
+        """Update the configuration of the area using the provided arguments."""
         if not self.config:
             return
         self.config.update_config_parameters(**kwargs)

--- a/src/gsy_e/models/area/event_dispatcher.py
+++ b/src/gsy_e/models/area/event_dispatcher.py
@@ -32,7 +32,7 @@ from gsy_e.models.area.redis_dispatcher.market_event_dispatcher import (
     AreaRedisMarketEventDispatcher)
 from gsy_e.models.area.redis_dispatcher.market_notify_event_subscriber import (
     MarketNotifyEventSubscriber)
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.market.market_structures import AvailableMarketTypes
 from gsy_e.models.strategy.area_agents.balancing_agent import BalancingAgent
 from gsy_e.models.strategy.area_agents.future_agent import FutureAgent
@@ -221,8 +221,8 @@ class AreaDispatcher:
             self.area.strategy.event_on_disabled_area()
 
     @staticmethod
-    def _create_agent_object(owner: "Area", higher_market: Market,
-                             lower_market: Market, market_type: AvailableMarketTypes
+    def _create_agent_object(owner: "Area", higher_market: MarketBase,
+                             lower_market: MarketBase, market_type: AvailableMarketTypes
                              ) -> Union[OneSidedAgent, SettlementAgent, BalancingAgent]:
         agent_constructor_arguments = {
             "owner": owner,
@@ -276,7 +276,7 @@ class AreaDispatcher:
             return False
         return True
 
-    def create_area_agents_for_future_markets(self, market: Market) -> None:
+    def create_area_agents_for_future_markets(self, market: MarketBase) -> None:
         """Create area agents for future markets; There should only be one per Area at any time."""
         if not self._should_agent_be_created:
             return
@@ -290,13 +290,13 @@ class AreaDispatcher:
 
         self._future_agent = iaa
 
-    def create_area_agents(self, market_type: AvailableMarketTypes, market: Market) -> None:
+    def create_area_agents(self, market_type: AvailableMarketTypes, market: MarketBase) -> None:
         """
         Create interarea agents for all market types, and store their reference to the respective
         dict.
         Args:
             market_type: Type of the market (spot/settlement/balancing/future)
-            market: Market object that will be associated with this interarea agent
+            market: MarketBase object that will be associated with this interarea agent
 
         Returns: None
 

--- a/src/gsy_e/models/area/markets.py
+++ b/src/gsy_e/models/area/markets.py
@@ -25,7 +25,7 @@ from pendulum import DateTime
 from gsy_e.gsy_e_core.util import is_time_slot_in_simulation_duration
 from gsy_e.models.area.market_rotators import (BaseRotator, DefaultMarketRotator,
                                                SettlementMarketRotator, FutureMarketRotator)
-from gsy_e.models.market import GridFee, Market
+from gsy_e.models.market import GridFee, MarketBase
 from gsy_e.models.market.balancing import BalancingMarket
 from gsy_e.models.market.future import FutureMarkets
 from gsy_e.models.market.market_structures import AvailableMarketTypes
@@ -44,11 +44,11 @@ class AreaMarkets:
     def __init__(self, area_log):
         self.log = area_log
         # Children trade in `markets`
-        self.markets:  Dict[DateTime, Market] = OrderedDict()
+        self.markets:  Dict[DateTime, MarketBase] = OrderedDict()
         self.balancing_markets:  Dict[DateTime, BalancingMarket] = OrderedDict()
         self.settlement_markets: Dict[DateTime, TwoSidedMarket] = OrderedDict()
         # Past markets:
-        self.past_markets:  Dict[DateTime, Market] = OrderedDict()
+        self.past_markets:  Dict[DateTime, MarketBase] = OrderedDict()
         self.past_balancing_markets:  Dict[DateTime, BalancingMarket] = OrderedDict()
         self.past_settlement_markets: Dict[DateTime, TwoSidedMarket] = OrderedDict()
         # TODO: rename and refactor in the frame of D3ASIM-3633:
@@ -115,7 +115,7 @@ class AreaMarkets:
         self._update_indexed_future_markets()
 
     @staticmethod
-    def _select_market_class(market_type: AvailableMarketTypes) -> type(Market):
+    def _select_market_class(market_type: AvailableMarketTypes) -> type(MarketBase):
         """Select market class dependent on the global config."""
         if market_type == AvailableMarketTypes.SPOT:
             if ConstSettings.IAASettings.MARKET_TYPE == SpotMarketTypeEnum.ONE_SIDED.value:
@@ -164,9 +164,9 @@ class AreaMarkets:
         self.log.trace("Adding %s market", time_slot.format(TIME_FORMAT))
 
     @staticmethod
-    def _create_market(market_class: Market,
+    def _create_market(market_class: MarketBase,
                        time_slot: DateTime, area: "Area",
-                       market_type: AvailableMarketTypes) -> Market:
+                       market_type: AvailableMarketTypes) -> MarketBase:
         """Create market for specific time_slot and market type."""
         market = market_class(
             time_slot=time_slot,

--- a/src/gsy_e/models/area/stats.py
+++ b/src/gsy_e/models/area/stats.py
@@ -27,7 +27,7 @@ from pendulum import DateTime
 from gsy_e import limit_float_precision
 from gsy_e.gsy_e_core.util import area_name_from_area_or_iaa_name, add_or_create_key, \
     area_sells_to_child, child_buys_from_area
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.strategy.load_hours import LoadHoursStrategy
 from gsy_e.models.strategy.pv import PVStrategy
 
@@ -137,7 +137,7 @@ class AreaStats:
         return out_dict
 
     @property
-    def current_market(self) -> Market:
+    def current_market(self) -> MarketBase:
         """Return the current market object"""
         past_markets = list(self._markets.past_markets.values())
         return past_markets[-1] if len(past_markets) > 0 else None

--- a/src/gsy_e/models/market/__init__.py
+++ b/src/gsy_e/models/market/__init__.py
@@ -59,7 +59,7 @@ def lock_market_action(function):
     return wrapper
 
 
-class Market:
+class MarketBase:
 
     def __init__(self, time_slot=None, bc=None, notification_listener=None, readonly=False,
                  grid_fee_type=ConstSettings.IAASettings.GRID_FEE_TYPE,
@@ -188,7 +188,7 @@ class Market:
         self._avg_offer_price = None
 
     def __repr__(self):  # pragma: no cover
-        return "<Market{} offers: {} (E: {} kWh V: {}) trades: {} (E: {} kWh, V: {})>".format(
+        return "<MarketBase{} offers: {} (E: {} kWh V: {}) trades: {} (E: {} kWh, V: {})>".format(
             " {}".format(self.time_slot_str),
             len(self.offers),
             sum(o.energy for o in self.offers.values()),

--- a/src/gsy_e/models/market/one_sided.py
+++ b/src/gsy_e/models/market/one_sided.py
@@ -29,12 +29,12 @@ from gsy_e.gsy_e_core.exceptions import (
     InvalidOffer, MarketReadOnlyException, OfferNotFoundException, InvalidTrade, MarketException)
 from gsy_e.gsy_e_core.util import short_offer_bid_log_str
 from gsy_e.events.event_structures import MarketEvent
-from gsy_e.models.market import Market, lock_market_action
+from gsy_e.models.market import MarketBase, lock_market_action
 
 log = getLogger(__name__)
 
 
-class OneSidedMarket(Market):
+class OneSidedMarket(MarketBase):
     """Class responsible for dealing with one sided markets.
 
     The default market type that D3A simulation uses.

--- a/src/gsy_e/models/strategy/__init__.py
+++ b/src/gsy_e/models/strategy/__init__.py
@@ -40,7 +40,7 @@ from gsy_e.gsy_e_core.util import append_or_create_key
 from gsy_e.events import EventMixin
 from gsy_e.events.event_structures import AreaEvent, MarketEvent
 from gsy_e.models.base import AreaBehaviorBase
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.strategy.settlement.strategy import SettlementMarketStrategyInterface
 
 log = getLogger(__name__)
@@ -99,7 +99,7 @@ class _TradeLookerUpper:
     def __init__(self, owner_name: str):
         self.owner_name = owner_name
 
-    def __getitem__(self, market: Market) -> Generator[Trade, None, None]:
+    def __getitem__(self, market: MarketBase) -> Generator[Trade, None, None]:
         for trade in market.trades:
             owner_name = self.owner_name
             if owner_name in (trade.seller, trade.buyer):
@@ -181,7 +181,7 @@ class MarketStrategyConnectionRedisAdapter:
         self._send_events_to_market("DELETE_OFFER", market_id, data,
                                     self._redis_delete_offer_response)
 
-    def _send_events_to_market(self, event_type_str: str, market_id: Union[str, Market],
+    def _send_events_to_market(self, event_type_str: str, market_id: Union[str, MarketBase],
                                data: dict, callback: Callable) -> None:
         if not isinstance(market_id, str):
             market_id = market_id.id
@@ -226,8 +226,8 @@ class MarketStrategyConnectionRedisAdapter:
 
 class MarketStrategyConnectionAdapter:
     """
-    Adapter to the Market class. Used by default when accessing the market object directly and not
-    via Redis
+    Adapter to the MarketBase class. Used by default when accessing the market object directly and
+    not via Redis.
     """
     @staticmethod
     def accept_offer(offer_parameters: AcceptOfferParameters) -> Trade:
@@ -353,7 +353,7 @@ class Offers:
     # pylint: disable=too-many-arguments
     def can_offer_be_posted(
             self, offer_energy: float, offer_price: float, available_energy: float,
-            market: "Market", replace_existing: bool = False,
+            market: "MarketBase", replace_existing: bool = False,
             time_slot: Optional[DateTime] = None) -> bool:
         """
         Check whether an offer with the specified parameters can be posted on the market
@@ -529,7 +529,7 @@ class BaseStrategy(EventMixin, AreaBehaviorBase, ABC):
         """Get list of posted offers from a market"""
         return self.offers.posted_in_market(market.id, time_slot)
 
-    def get_market_from_id(self, market_id: str) -> Optional[Market]:
+    def get_market_from_id(self, market_id: str) -> Optional[MarketBase]:
         """Retrieve a market object from the market_id."""
         # Look in spot and future markets first
         if not self.area:
@@ -650,7 +650,7 @@ class BaseStrategy(EventMixin, AreaBehaviorBase, ABC):
             replace_existing=replace_existing)
 
     @property
-    def spot_market(self) -> "Market":
+    def spot_market(self) -> "MarketBase":
         """Return the spot_market member of the area."""
         return self.area.spot_market
 
@@ -716,7 +716,7 @@ class BidEnabledStrategy(BaseStrategy):
         offer_costs = super().energy_traded_costs(market_id, time_slot)
         return offer_costs + self._traded_bid_costs(market_id, time_slot)
 
-    def _remove_existing_bids(self, market: Market) -> None:
+    def _remove_existing_bids(self, market: MarketBase) -> None:
         """Remove all existing bids in the market."""
         for bid in self.get_posted_bids(market):
             assert bid.buyer == self.owner.name
@@ -724,7 +724,7 @@ class BidEnabledStrategy(BaseStrategy):
 
     # pylint: disable=too-many-arguments
     def post_bid(
-            self, market: Market, price: float, energy: float, replace_existing: bool = True,
+            self, market: MarketBase, price: float, energy: float, replace_existing: bool = True,
             attributes: Optional[Dict] = None, requirements: Optional[Dict] = None,
             time_slot: Optional[DateTime] = None) -> Bid:
         """
@@ -883,7 +883,7 @@ class BidEnabledStrategy(BaseStrategy):
         return len([bid for bid in self._bids[market_id]
                     if time_slot is None or bid.time_slot == time_slot]) > 0
 
-    def post_first_bid(self, market: "Market", energy_Wh: float,
+    def post_first_bid(self, market: "MarketBase", energy_Wh: float,
                        initial_energy_rate: float) -> Optional[Bid]:
         """Post first and only bid for the strategy. Will fail if another bid already exists."""
         # It will be safe to remove this check once we remove the event_market_cycle being
@@ -901,7 +901,8 @@ class BidEnabledStrategy(BaseStrategy):
             energy_Wh / 1000.0,
         )
 
-    def get_posted_bids(self, market: "Market", time_slot: Optional[DateTime] = None) -> List[Bid]:
+    def get_posted_bids(
+            self, market: "MarketBase", time_slot: Optional[DateTime] = None) -> List[Bid]:
         """Get list of posted bids from a market"""
         if market.id not in self._bids:
             return []
@@ -946,7 +947,7 @@ class BidEnabledStrategy(BaseStrategy):
             self._traded_bids = {}
             super().event_market_cycle()
 
-    def assert_if_trade_bid_price_is_too_high(self, market: "Market", trade: "Trade") -> None:
+    def assert_if_trade_bid_price_is_too_high(self, market: "MarketBase", trade: "Trade") -> None:
         """
         Assert whether the bid rate of the trade is less than the original bid rate. Useful
         for asserting that the clearing rate is lower than the rate that was posted originally on

--- a/src/gsy_e/models/strategy/area_agents/one_sided_agent.py
+++ b/src/gsy_e/models/strategy/area_agents/one_sided_agent.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 from numpy.random import random
 
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.strategy.area_agents.inter_area_agent import InterAreaAgent
 from gsy_e.models.strategy.area_agents.one_sided_engine import IAAEngine
 
@@ -39,7 +39,7 @@ class OneSidedAgent(InterAreaAgent):
         """Prevent IAAEngines from trading their counterpart's offers"""
         return all(offer.id not in engine.forwarded_offers.keys() for engine in self.engines)
 
-    def get_market_from_market_id(self, market_id: str) -> Optional[Market]:
+    def get_market_from_market_id(self, market_id: str) -> Optional[MarketBase]:
         """Return Market object from market_id."""
         if self.lower_market.id == market_id:
             return self.lower_market

--- a/src/gsy_e/models/strategy/external_strategies/__init__.py
+++ b/src/gsy_e/models/strategy/external_strategies/__init__.py
@@ -33,7 +33,7 @@ from gsy_e.gsy_e_core.exceptions import MarketException, GSyException
 from gsy_e.gsy_e_core.global_objects_singleton import global_objects
 from gsy_e.gsy_e_core.redis_connections.redis_area_market_communicator import (
     ResettableCommunicator, ExternalConnectionCommunicator)
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 
 if TYPE_CHECKING:
     from gsy_e.models.area import Area
@@ -133,7 +133,7 @@ class ExternalMixin:
     # alternative is to include here the mixed-in class dependencies as type annotations
     area: "Area"
     owner: "Area"
-    spot_market: "Market"
+    spot_market: "MarketBase"
     deactivate: Callable
     get_state: Callable
     restore_state: Callable
@@ -284,14 +284,14 @@ class ExternalMixin:
             }
         return response
 
-    def _get_market_from_command_argument(self, arguments: Dict) -> Market:
+    def _get_market_from_command_argument(self, arguments: Dict) -> MarketBase:
         """Extract the time_slot from command argument and return the needed market."""
         if arguments.get("time_slot") is None:
             return self.spot_market
         time_slot = str_to_pendulum_datetime(arguments["time_slot"])
         return self._get_market_from_time_slot(time_slot)
 
-    def _get_market_from_time_slot(self, time_slot: DateTime) -> Market:
+    def _get_market_from_time_slot(self, time_slot: DateTime) -> MarketBase:
         """Get the market instance based on the time_slot."""
         market = self.area.get_market(time_slot)
 

--- a/src/gsy_e/models/strategy/external_strategies/storage.py
+++ b/src/gsy_e/models/strategy/external_strategies/storage.py
@@ -22,7 +22,7 @@ from typing import Dict, List, TYPE_CHECKING, Callable
 from pendulum import DateTime
 
 from gsy_e.gsy_e_core.util import get_market_maker_rate_from_config
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.strategy.external_strategies import (
     ExternalMixin, IncomingRequest, ExternalStrategyConnectionManager, default_market_info)
 from gsy_e.models.strategy.storage import StorageStrategy
@@ -49,7 +49,7 @@ class StorageExternalMixin(ExternalMixin):
     Should always be inherited together with a superclass of StorageStrategy.
     """
 
-    def filtered_market_bids(self, market: Market) -> List[Dict]:
+    def filtered_market_bids(self, market: MarketBase) -> List[Dict]:
         """
         Get a representation of each of the asset's bids from the market.
         Args:

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -37,7 +37,7 @@ from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.gsy_e_core.exceptions import MarketException
 from gsy_e.gsy_e_core.util import get_market_maker_rate_from_config
 from gsy_e.models.base import AssetType
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.state import LoadState
 from gsy_e.models.strategy import BidEnabledStrategy, utils
 from gsy_e.models.strategy.future.strategy import future_market_strategy_factory
@@ -286,7 +286,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
         offers = market.most_affordable_offers
         return random.choice(offers)
 
-    def _offer_rate_can_be_accepted(self, offer: Offer, market_slot: Market):
+    def _offer_rate_can_be_accepted(self, offer: Offer, market_slot: MarketBase):
         """Check if the offer rate is less than what the device wants to pay."""
         max_affordable_offer_rate = self.bid_update.get_updated_rate(market_slot.time_slot)
         return (

--- a/src/gsy_e/models/strategy/settlement/strategy.py
+++ b/src/gsy_e/models/strategy/settlement/strategy.py
@@ -21,7 +21,7 @@ from pendulum import duration
 
 from gsy_e.constants import SettlementTemplateStrategiesConstants
 from gsy_e.gsy_e_core.exceptions import MarketException
-from gsy_e.models.market import Market  # NOQA
+from gsy_e.models.market import MarketBase
 from gsy_e.models.strategy.update_frequency import (TemplateStrategyBidUpdater,
                                                     TemplateStrategyOfferUpdater)
 
@@ -34,7 +34,7 @@ class SettlementTemplateStrategyBidUpdater(TemplateStrategyBidUpdater):
     """Version of TemplateStrategyBidUpdater class for settlement markets"""
 
     @staticmethod
-    def get_all_markets(area: "Area") -> Iterable[Market]:
+    def get_all_markets(area: "Area") -> Iterable[MarketBase]:
         return area.settlement_markets.values()
 
     @staticmethod
@@ -46,7 +46,7 @@ class SettlementTemplateStrategyOfferUpdater(TemplateStrategyOfferUpdater):
     """Version of TemplateStrategyOfferUpdater class for settlement markets"""
 
     @staticmethod
-    def get_all_markets(area: "Area") -> Iterable[Market]:
+    def get_all_markets(area: "Area") -> Iterable[MarketBase]:
         return area.settlement_markets.values()
 
     @staticmethod
@@ -165,7 +165,7 @@ class SettlementMarketStrategy(SettlementMarketStrategyInterface):
 
     @staticmethod
     def _get_settlement_market_by_id(strategy: "BidEnabledStrategy",
-                                     market_id: str) -> Optional["Market"]:
+                                     market_id: str) -> Optional["MarketBase"]:
         markets = [market for market in strategy.area.settlement_markets.values()
                    if market.id == market_id]
         if not markets:

--- a/src/gsy_e/models/strategy/smart_meter.py
+++ b/src/gsy_e/models/strategy/smart_meter.py
@@ -32,7 +32,7 @@ from gsy_e.gsy_e_core.exceptions import GSyException, MarketException
 from gsy_e.gsy_e_core.global_objects_singleton import global_objects
 from gsy_e.gsy_e_core.util import (get_market_maker_rate_from_config, should_read_profile_from_db)
 from gsy_e.models.base import AssetType
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.state import SmartMeterState
 from gsy_e.models.strategy import BidEnabledStrategy, utils
 from gsy_e.models.strategy.update_frequency import (
@@ -535,7 +535,7 @@ class SmartMeterStrategy(BidEnabledStrategy):
                 energy_rate_decrease_per_update=rate_change,
                 fit_to_limit=fit_to_limit)
 
-    def _offer_rate_can_be_accepted(self, offer: Offer, market_slot: Market):
+    def _offer_rate_can_be_accepted(self, offer: Offer, market_slot: MarketBase):
         """Check if the offer rate is less than what the device wants to pay."""
         max_affordable_offer_rate = self.bid_update.get_updated_rate(market_slot.time_slot)
         return (

--- a/tests/area/test_area.py
+++ b/tests/area/test_area.py
@@ -26,7 +26,7 @@ from pendulum import duration, today
 from gsy_e import constants
 from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.events.event_structures import AreaEvent, MarketEvent
-from gsy_e.models.area import Area, check_area_name_exists_in_parent_area
+from gsy_e.models.area import Area, Asset, Market, check_area_name_exists_in_parent_area
 from gsy_e.models.area.events import Events
 from gsy_e.models.config import SimulationConfig
 from gsy_e.models.market.market_structures import AvailableMarketTypes
@@ -331,3 +331,27 @@ class TestFunctions:
         area = Area(name="Street", children=[Area(name="House")], )
         assert check_area_name_exists_in_parent_area(area, "House") is True
         assert check_area_name_exists_in_parent_area(area, "House 2") is False
+
+
+class TestMarket:
+    """Tests for the Market class."""
+
+    @staticmethod
+    def test_init_with_children():
+        """The class can be correctly instantiated with children."""
+        Market(name="Street", children=[Area(name="House")])
+
+
+class TestAsset:
+    """Tests for the Asset class."""
+
+    @staticmethod
+    def test_init_fails_with_children():
+        """The class can't be initialized with children."""
+        with pytest.raises(ValueError):
+            Asset(name="Street", children=[Area(name="House")])
+
+    @staticmethod
+    def test_init_succeeds_without():
+        """The class can be initialized without children."""
+        Asset(name="Some device")

--- a/tests/area/test_area.py
+++ b/tests/area/test_area.py
@@ -15,21 +15,19 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import unittest
+# pylint: disable=missing-function-docstring
 from unittest.mock import MagicMock, patch, Mock, call
 
+import pytest
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.enums import SpotMarketTypeEnum, BidOfferMatchAlgoEnum
-from parameterized import parameterized
 from pendulum import duration, today
 
 from gsy_e import constants
 from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.events.event_structures import AreaEvent, MarketEvent
 from gsy_e.models.area import Area, check_area_name_exists_in_parent_area
-from gsy_e.models.area.event_dispatcher import AreaDispatcher
 from gsy_e.models.area.events import Events
-from gsy_e.models.area.stats import AreaStats
 from gsy_e.models.config import SimulationConfig
 from gsy_e.models.market.market_structures import AvailableMarketTypes
 from gsy_e.models.strategy.storage import StorageStrategy
@@ -37,7 +35,25 @@ from gsy_e.models.strategy.storage import StorageStrategy
 
 class TestArea:
     """Test the Area class behavior and state controllers."""
-    def setup_method(self):
+
+    @staticmethod
+    @pytest.fixture(name="config")
+    def config_fixture():
+        """Instantiate a mocked configuration."""
+        config = MagicMock(spec=SimulationConfig)
+        config.slot_length = duration(minutes=15)
+        config.tick_length = duration(seconds=15)
+        config.ticks_per_slot = int(config.slot_length.seconds / config.tick_length.seconds)
+        config.start_date = today(tz=constants.TIME_ZONE)
+        config.sim_duration = duration(days=1)
+        config.grid_fee_type = 1
+        config.end_date = config.start_date + config.sim_duration
+
+        return config
+
+    @staticmethod
+    def setup_method():
+        GlobalConfig.sim_duration = duration(days=1)
         ConstSettings.BalancingSettings.ENABLE_BALANCING_MARKET = True
         DeviceRegistry.REGISTRY = {
             "H1 General Load": (33, 35),
@@ -46,88 +62,72 @@ class TestArea:
             "H1 Storage2": (23, 25),
         }
 
-        self.strategy = MagicMock(spec=StorageStrategy)
-        self.config = MagicMock(spec=SimulationConfig)
-        self.config.slot_length = duration(minutes=15)
-        self.config.tick_length = duration(seconds=15)
-        self.config.ticks_per_slot = int(self.config.slot_length.seconds /
-                                         self.config.tick_length.seconds)
-        self.config.start_date = today(tz=constants.TIME_ZONE)
-        GlobalConfig.sim_duration = duration(days=1)
-        self.config.sim_duration = duration(days=1)
-        self.config.grid_fee_type = 1
-        self.config.end_date = self.config.start_date + self.config.sim_duration
-        self.area = Area("test_area", None, None, self.strategy,
-                         self.config, None, grid_fee_percentage=1)
-        self.area_child = Area("test_area_c", None, None, self.strategy,
-                               self.config, None, grid_fee_percentage=1)
-        self.area_child.parent = self.area
-        self.area.children = [self.area_child]
-        self.area.grid_fee_percentage = 1
-        self.dispatcher = AreaDispatcher(self.area)
-        self.stats = AreaStats(self.area._markets, self.area)
-
-    def teardown_method(self):
+    @staticmethod
+    def teardown_method():
         ConstSettings.IAASettings.MARKET_TYPE = SpotMarketTypeEnum.ONE_SIDED.value
         ConstSettings.IAASettings.BID_OFFER_MATCH_TYPE = BidOfferMatchAlgoEnum.PAY_AS_BID.value
         ConstSettings.GeneralSettings.EVENT_DISPATCHING_VIA_REDIS = False
         constants.RETAIN_PAST_MARKET_STRATEGIES_STATE = False
 
-    def test_respective_area_grid_fee_is_applied(self):
-        self.config.grid_fee_type = 2
-        self.area = Area(name="Street", children=[Area(name="House")],
-                         grid_fee_percentage=5, config=self.config)
-        self.area.parent = Area(name="GRID", config=self.config)
-        self.area.activate()
-        assert self.area.spot_market.fee_class.grid_fee_rate == 0.05
-        self.area.spot_market.offer(1, 1, "test", "test")
-        assert list(self.area.spot_market.offers.values())[0].price == 1.05
+    @staticmethod
+    def test_respective_area_grid_fee_is_applied(config):
+        config.grid_fee_type = 2
+        area = Area(name="Street", children=[Area(name="House")],
+                         grid_fee_percentage=5, config=config)
+        area.parent = Area(name="GRID", config=config)
+        area.activate()
+        assert area.spot_market.fee_class.grid_fee_rate == 0.05
+        area.spot_market.offer(1, 1, "test", "test")
+        assert list(area.spot_market.offers.values())[0].price == 1.05
 
-    def test_delete_past_markets_instead_of_last(self):
+    @staticmethod
+    def test_delete_past_markets_instead_of_last(config):
         constants.RETAIN_PAST_MARKET_STRATEGIES_STATE = False
-        self.area = Area(name="Street", children=[Area(name="House")],
-                         config=self.config, grid_fee_percentage=5)
-        self.area.activate()
-        self.area._bc = None
+        area = Area(name="Street", children=[Area(name="House")],
+                         config=config, grid_fee_percentage=5)
+        area.activate()
+        area._bc = None
 
-        self.area.cycle_markets(False, False, False)
-        assert len(self.area.past_markets) == 0
+        area.cycle_markets(False, False, False)
+        assert len(area.past_markets) == 0
 
-        current_time = today(tz=constants.TIME_ZONE).add(minutes=self.config.slot_length.minutes)
-        self.area._markets.rotate_markets(current_time)
-        assert len(self.area.past_markets) == 1
+        current_time = today(tz=constants.TIME_ZONE).add(minutes=config.slot_length.minutes)
+        area._markets.rotate_markets(current_time)
+        assert len(area.past_markets) == 1
 
-        self.area._markets.create_new_spot_market(
-            current_time, AvailableMarketTypes.SPOT, self.area)
-        current_time = today(tz=constants.TIME_ZONE).add(minutes=2*self.config.slot_length.minutes)
-        self.area._markets.rotate_markets(current_time)
-        assert len(self.area.past_markets) == 1
-        assert (list(self.area.past_markets)[-1].time_slot ==
-                today(tz=constants.TIME_ZONE).add(minutes=self.config.slot_length.minutes))
+        area._markets.create_new_spot_market(
+            current_time, AvailableMarketTypes.SPOT, area)
+        current_time = today(tz=constants.TIME_ZONE).add(minutes=2*config.slot_length.minutes)
+        area._markets.rotate_markets(current_time)
+        assert len(area.past_markets) == 1
+        assert (list(area.past_markets)[-1].time_slot ==
+                today(tz=constants.TIME_ZONE).add(minutes=config.slot_length.minutes))
 
-    def test_keep_past_markets(self):
+    @staticmethod
+    def test_keep_past_markets(config):
         constants.RETAIN_PAST_MARKET_STRATEGIES_STATE = True
-        self.area = Area(name="Street", children=[Area(name="House")],
-                         config=self.config, grid_fee_percentage=5)
-        self.area.activate()
-        self.area._bc = None
+        area = Area(name="Street", children=[Area(name="House")],
+                         config=config, grid_fee_percentage=5)
+        area.activate()
+        area._bc = None
 
-        self.area.cycle_markets(False, False, False)
-        assert len(self.area.past_markets) == 0
+        area.cycle_markets(False, False, False)
+        assert len(area.past_markets) == 0
 
         current_time = today(tz=constants.TIME_ZONE).add(
-            minutes=self.config.slot_length.total_minutes())
-        self.area._markets.rotate_markets(current_time)
-        assert len(self.area.past_markets) == 1
+            minutes=config.slot_length.total_minutes())
+        area._markets.rotate_markets(current_time)
+        assert len(area.past_markets) == 1
 
-        self.area._markets.create_new_spot_market(
-            current_time, AvailableMarketTypes.SPOT, self.area)
+        area._markets.create_new_spot_market(
+            current_time, AvailableMarketTypes.SPOT, area)
         current_time = today(tz=constants.TIME_ZONE).add(
-            minutes=2*self.config.slot_length.total_minutes())
-        self.area._markets.rotate_markets(current_time)
-        assert len(self.area.past_markets) == 2
+            minutes=2*config.slot_length.total_minutes())
+        area._markets.rotate_markets(current_time)
+        assert len(area.past_markets) == 2
 
-    def test_get_restore_state_get_called_on_all_areas(self):
+    @staticmethod
+    def test_get_restore_state_get_called_on_all_areas():
         strategy = MagicMock(spec=StorageStrategy)
         bat = Area(name="battery", strategy=strategy)
 
@@ -154,160 +154,180 @@ class TestArea:
         bat.get_state()
         strategy.get_state.assert_called_once()
 
+    @staticmethod
     @patch("gsy_e.models.area.Area._consume_commands_from_aggregator", Mock())
     @patch("gsy_e.models.area.Area._update_myco_matcher", Mock())
     @patch("gsy_e.models.area.bid_offer_matcher.match_recommendations")
-    def test_tick(self, mock_match_recommendations):
+    def test_tick(mock_match_recommendations, config):
         """Test the correct chain of function calls in the Area's tick function."""
         manager = Mock()
-        manager.attach_mock(self.area._consume_commands_from_aggregator, "consume_commands")
-        manager.attach_mock(self.area._update_myco_matcher, "update_matcher")
+        strategy = MagicMock(spec=StorageStrategy)
+        area = Area("test_area", None, None, strategy, config, None, grid_fee_percentage=1)
+        area_child = Area("test_area_c", None, None, strategy, config, None, grid_fee_percentage=1)
+        area_child.parent = area
+        area.children = [area_child]
+        area.grid_fee_percentage = 1
+
+        manager.attach_mock(area._consume_commands_from_aggregator, "consume_commands")
+        manager.attach_mock(area._update_myco_matcher, "update_matcher")
         manager.attach_mock(mock_match_recommendations, "match")
 
         ConstSettings.IAASettings.MARKET_TYPE = SpotMarketTypeEnum.ONE_SIDED.value
-        self.area.tick()
+        area.tick()
         assert manager.mock_calls == [call.consume_commands()]
 
         # TWO Sided markets with internal matching, the order should be ->
         # consume commands from aggregator -> update myco cache -> call myco clearing
         manager.reset_mock()
         ConstSettings.IAASettings.MARKET_TYPE = SpotMarketTypeEnum.TWO_SIDED.value
-        self.area.strategy = None
-        self.area.tick()
+        area.strategy = None
+        area.tick()
         assert manager.mock_calls == [call.consume_commands(), call.update_matcher(), call.match()]
 
         # TWO Sided markets with external matching, the order should be ->
         # call myco clearing -> consume commands from aggregator -> update myco cache
         manager.reset_mock()
         ConstSettings.IAASettings.BID_OFFER_MATCH_TYPE = BidOfferMatchAlgoEnum.EXTERNAL.value
-        self.area.tick()
+        area.tick()
         assert manager.mock_calls == [call.match(), call.consume_commands(), call.update_matcher()]
 
 
-class TestEventDispatcher(unittest.TestCase):
+class TestEventDispatcher:
+    """Test the dispatching of area events."""
 
-    def test_area_dispatches_activate_to_strategies_despite_connect_enable(self):
-        self.area = Area(name="test_area")
-        self.area.events = MagicMock(spec=Events)
-        self.area.events.is_enabled = False
-        self.area.events.is_connected = False
-        assert self.area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
-        self.area.events.is_enabled = True
-        self.area.events.is_connected = True
-        assert self.area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
-        self.area.events.is_enabled = True
-        self.area.events.is_connected = False
-        assert self.area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
-        self.area.events.is_enabled = False
-        self.area.events.is_connected = True
-        assert self.area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
+    @staticmethod
+    @pytest.fixture(name="strategy_mock")
+    def strategy_fixture():
+        strategy_mock = MagicMock()
+        strategy_mock.event_listener = MagicMock()
+        area = Area(name="test_area")
+        area.strategy = strategy_mock
+        area.events = MagicMock(spec=Events)
 
-    def test_are_dispatches_other_events_only_if_connected_and_enabled(self):
-        self.area = Area(name="test_area")
-        self.area.events = MagicMock(spec=Events)
-        self.area.events.is_enabled = False
-        self.area.events.is_connected = False
-        assert not self.area.dispatcher._should_dispatch_to_strategies(
-            AreaEvent.MARKET_CYCLE)
-        self.area.events.is_enabled = True
-        self.area.events.is_connected = False
-        assert not self.area.dispatcher._should_dispatch_to_strategies(
-            AreaEvent.MARKET_CYCLE)
-        self.area.events.is_enabled = False
-        self.area.events.is_connected = True
-        assert not self.area.dispatcher._should_dispatch_to_strategies(
-            AreaEvent.MARKET_CYCLE)
-        self.area.events.is_enabled = True
-        self.area.events.is_connected = True
-        assert self.area.dispatcher._should_dispatch_to_strategies(
-            AreaEvent.MARKET_CYCLE)
+        return area
 
-    @parameterized.expand([(AreaEvent.MARKET_CYCLE, "cycle_markets"),
-                           (AreaEvent.ACTIVATE, "activate"),
-                           (AreaEvent.TICK, "tick")])
-    def test_event_listener_calls_area_methods_for_area_events(self, event_type, area_method):
+    @staticmethod
+    def test_area_dispatches_activate_to_strategies_despite_connect_enable():
+        area = Area(name="test_area")
+        area.events = MagicMock(spec=Events)
+        area.events.is_enabled = False
+        area.events.is_connected = False
+        assert area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
+        area.events.is_enabled = True
+        area.events.is_connected = True
+        assert area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
+        area.events.is_enabled = True
+        area.events.is_connected = False
+        assert area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
+        area.events.is_enabled = False
+        area.events.is_connected = True
+        assert area.dispatcher._should_dispatch_to_strategies(AreaEvent.ACTIVATE)
+
+    @staticmethod
+    def test_are_dispatches_other_events_only_if_connected_and_enabled():
+        area = Area(name="test_area")
+        area.events = MagicMock(spec=Events)
+        area.events.is_enabled = False
+        area.events.is_connected = False
+        assert not area.dispatcher._should_dispatch_to_strategies(AreaEvent.MARKET_CYCLE)
+
+        area.events.is_enabled = True
+        area.events.is_connected = False
+        assert not area.dispatcher._should_dispatch_to_strategies(AreaEvent.MARKET_CYCLE)
+
+        area.events.is_enabled = False
+        area.events.is_connected = True
+        assert not area.dispatcher._should_dispatch_to_strategies(AreaEvent.MARKET_CYCLE)
+
+        area.events.is_enabled = True
+        area.events.is_connected = True
+        assert area.dispatcher._should_dispatch_to_strategies(AreaEvent.MARKET_CYCLE)
+
+    @staticmethod
+    @pytest.mark.parametrize("event_type, area_method", [
+        (AreaEvent.MARKET_CYCLE, "cycle_markets"), (AreaEvent.ACTIVATE, "activate"),
+        (AreaEvent.TICK, "tick")])
+    def test_event_listener_calls_area_methods_for_area_events(event_type, area_method):
         function_mock = MagicMock(name=area_method)
         area = Area(name="test_area")
         setattr(area, area_method, function_mock)
         area.dispatcher.event_listener(event_type)
         assert function_mock.call_count == 1
 
-    def strategy_mock(self):
-        strategy_mock = MagicMock()
-        strategy_mock.event_listener = MagicMock()
-        area = Area(name="test_area")
-        area.strategy = strategy_mock
-        area.events = MagicMock(spec=Events)
-        return area
-
-    @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.OFFER_TRADED,),
-                           (MarketEvent.OFFER_SPLIT, ),
-                           (MarketEvent.BID_TRADED, ),
-                           (MarketEvent.BID_DELETED, ),
-                           (MarketEvent.OFFER_DELETED, )])
-    def test_event_listener_dispatches_to_strategy_if_enabled_connected(
-            self, event_type
-    ):
-        area = self.strategy_mock()
+    @staticmethod
+    @pytest.mark.parametrize("event_type", [
+        (MarketEvent.OFFER, ),
+        (MarketEvent.OFFER_TRADED,),
+        (MarketEvent.OFFER_SPLIT, ),
+        (MarketEvent.BID_TRADED, ),
+        (MarketEvent.BID_DELETED, ),
+        (MarketEvent.OFFER_DELETED, )])
+    def test_event_listener_dispatches_to_strategy_if_enabled_connected(event_type, strategy_mock):
+        area = strategy_mock
         area.events.is_enabled = True
         area.events.is_connected = True
         area.dispatcher.event_listener(event_type)
         assert area.strategy.event_listener.call_count == 1
 
-    @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.OFFER_TRADED,),
-                           (MarketEvent.OFFER_SPLIT, ),
-                           (MarketEvent.BID_TRADED, ),
-                           (MarketEvent.BID_DELETED, ),
-                           (MarketEvent.OFFER_DELETED, )])
-    def test_event_listener_doesnt_dispatch_to_strategy_if_not_enabled(self, event_type):
-        area = self.strategy_mock()
+    @staticmethod
+    @pytest.mark.parametrize("event_type", [
+        (MarketEvent.OFFER, ),
+        (MarketEvent.OFFER_TRADED,),
+        (MarketEvent.OFFER_SPLIT, ),
+        (MarketEvent.BID_TRADED, ),
+        (MarketEvent.BID_DELETED, ),
+        (MarketEvent.OFFER_DELETED, )])
+    def test_event_listener_doesnt_dispatch_to_strategy_if_not_enabled(event_type, strategy_mock):
+        area = strategy_mock
         area.events.is_enabled = False
         area.events.is_connected = True
         area.dispatcher.event_listener(event_type)
         assert area.strategy.event_listener.call_count == 0
 
-    @parameterized.expand([(MarketEvent.OFFER, ),
-                           (MarketEvent.OFFER_TRADED,),
-                           (MarketEvent.OFFER_SPLIT, ),
-                           (MarketEvent.BID_TRADED, ),
-                           (MarketEvent.BID_DELETED, ),
-                           (MarketEvent.OFFER_DELETED, )])
+    @staticmethod
+    @pytest.mark.parametrize("event_type", [
+        (MarketEvent.OFFER, ),
+        (MarketEvent.OFFER_TRADED,),
+        (MarketEvent.OFFER_SPLIT, ),
+        (MarketEvent.BID_TRADED, ),
+        (MarketEvent.BID_DELETED, ),
+        (MarketEvent.OFFER_DELETED, )])
     def test_event_listener_doesnt_dispatch_to_strategy_if_not_connected(
-            self, event_type
-    ):
-        area = self.strategy_mock()
+            event_type, strategy_mock):
+        area = strategy_mock
         area.events.is_enabled = True
         area.events.is_connected = False
         area.dispatcher.event_listener(event_type)
         assert area.strategy.event_listener.call_count == 0
 
-    def test_event_on_disabled_area_triggered_for_market_cycle_on_disabled_area(self):
-        area = self.strategy_mock()
+    @staticmethod
+    def test_event_on_disabled_area_triggered_for_market_cycle_on_disabled_area(strategy_mock):
+        area = strategy_mock
         area.strategy.event_on_disabled_area = MagicMock()
         area.events.is_enabled = False
         area.events.is_connected = True
         area.dispatcher.event_listener(AreaEvent.MARKET_CYCLE)
         assert area.strategy.event_on_disabled_area.call_count == 1
 
-    def test_duplicate_area_in_the_same_parent_append(self):
+    @staticmethod
+    def test_duplicate_area_in_the_same_parent_append():
         area = Area(name="Street", children=[Area(name="House")], )
-        with self.assertRaises(Exception) as exception:
+        with pytest.raises(Exception) as exception:
             area.children.append(Area(name="House", children=[Area(name="House")], ))
-            self.assertEqual(exception, "Area name should be unique inside the same Parent Area")
+            assert exception == "Area name should be unique inside the same Parent Area"
 
-    def test_duplicate_area_in_the_same_parent_change_name(self):
+    @staticmethod
+    def test_duplicate_area_in_the_same_parent_change_name():
         child = Area(name="Street", )
-        parent = Area(name="Community", children=[child, Area(name="Street 2")]) # noqa
-        with self.assertRaises(Exception) as exception:
+        with pytest.raises(Exception) as exception:
             child.name = "Street 2"
-            self.assertEqual(exception, "Area name should be unique inside the same Parent Area")
+            assert exception == "Area name should be unique inside the same Parent Area"
 
 
-class TestFunctions(unittest.TestCase):
-
-    def test_check_area_name_exists_in_parent_area(self):
+class TestFunctions:
+    """Test utility functions in the area module."""
+    @staticmethod
+    def test_check_area_name_exists_in_parent_area():
         area = Area(name="Street", children=[Area(name="House")], )
-        self.assertTrue(check_area_name_exists_in_parent_area(area, "House"))
-        self.assertFalse(check_area_name_exists_in_parent_area(area, "House 2"))
+        assert check_area_name_exists_in_parent_area(area, "House") is True
+        assert check_area_name_exists_in_parent_area(area, "House 2") is False

--- a/tests/area/test_event_dispatcher.py
+++ b/tests/area/test_event_dispatcher.py
@@ -28,7 +28,7 @@ from pendulum import duration
 from gsy_e.events.event_structures import MarketEvent, AreaEvent
 from gsy_e.models.area import Area
 from gsy_e.models.area.event_dispatcher import AreaDispatcher
-from gsy_e.models.market import Market
+from gsy_e.models.market import MarketBase
 from gsy_e.models.market.balancing import BalancingMarket
 from gsy_e.models.market.future import FutureMarkets
 from gsy_e.models.market.market_structures import AvailableMarketTypes
@@ -93,7 +93,7 @@ class TestAreaDispatcher:
     @staticmethod
     def _create_iaa_and_markets_for_time_slot(dispatcher_object: AreaDispatcher,
                                               time_slot: DateTime,
-                                              market_class: Market,
+                                              market_class: MarketBase,
                                               market_type: AvailableMarketTypes):
         """Helps to create iaas for testing."""
         first_time_slot = time_slot
@@ -120,7 +120,7 @@ class TestAreaDispatcher:
     ])
     def test_create_area_agents_creates_correct_objects(self, market_type: AvailableMarketTypes,
                                                         spot_market_type: SpotMarketTypeEnum,
-                                                        market_class: Market,
+                                                        market_class: MarketBase,
                                                         expected_agent_type: InterAreaAgent,
                                                         area_dispatcher):
         """Test if create_area_agents creates correct objects in the agent dicts."""
@@ -159,7 +159,7 @@ class TestAreaDispatcher:
         [AvailableMarketTypes.BALANCING, BalancingMarket],
                              ])
     def test_event_market_cycle_deletes_all_old_iaas(self, market_type: AvailableMarketTypes,
-                                                     market_class: Market,
+                                                     market_class: MarketBase,
                                                      area_dispatcher):
         """Test whether iaas are deleted from the agent dicts."""
 


### PR DESCRIPTION
This is the first PR that handles the renaming of "Area" into "Market". This name should be used in every part of the code that affects either researchers or UI users. Internally, the `Area` class can be preserved because it represents a different concept (since it represents both markets and assets).