### PR TITLE
Revert mkdocs redirection address

### DIFF
--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -130,4 +130,4 @@ plugins:
     - redirects:
         redirect_maps:
             # When trying to reach the generic index page, redirect to the documentation page
-            'index.md': 'documentation.md'
+            '': 'documentation.md'


### PR DESCRIPTION
The local version can work without `index.md` but the production one returns a 404 error. This is another attempt to make the redirection work both locally and in production.