### PR TITLE
Redirect to the online version of the wiki

### DIFF
--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -129,5 +129,5 @@ plugins:
 
     - redirects:
         redirect_maps:
-            # When trying to reach the generic index page, redirect to the documentation page
-            '': 'documentation.md'
+            # When trying to reach the root page, redirect to the documentation page
+            '': 'https://gridsingularity.github.io/gsy-e/documentation/'


### PR DESCRIPTION
Unfortunately, the previous attempts did not work for both production and local versions. We revert to the initial version, with the redirect pointing to the online website.