### PR TITLE
Fix create_future_markets to avoid creating any future market if the global future duration is 0

### DIFF
--- a/src/gsy_e/models/market/future.py
+++ b/src/gsy_e/models/market/future.py
@@ -178,6 +178,8 @@ class FutureMarkets(TwoSidedMarket):
                               slot_length: duration,
                               config: "SimulationConfig") -> None:
         """Add sub dicts in order dictionaries for future market slots."""
+        if not GlobalConfig.FUTURE_MARKET_DURATION_HOURS:
+            return
         future_time_slot = current_market_time_slot.add(minutes=slot_length.total_minutes())
         most_future_slot = (future_time_slot +
                             duration(hours=GlobalConfig.FUTURE_MARKET_DURATION_HOURS))

--- a/src/gsy_e/models/market/future.py
+++ b/src/gsy_e/models/market/future.py
@@ -181,7 +181,7 @@ class FutureMarkets(TwoSidedMarket):
         if not GlobalConfig.FUTURE_MARKET_DURATION_HOURS:
             return
         future_time_slot = current_market_time_slot.add(minutes=slot_length.total_minutes())
-        most_future_slot = (future_time_slot +
+        most_future_slot = (current_market_time_slot +
                             duration(hours=GlobalConfig.FUTURE_MARKET_DURATION_HOURS))
         while future_time_slot <= most_future_slot:
             if (future_time_slot not in self.slot_bid_mapping and

--- a/tests/market/test_future.py
+++ b/tests/market/test_future.py
@@ -111,7 +111,7 @@ class TestFutureMarkets:
         for buffer in [future_market.slot_bid_mapping,
                        future_market.slot_offer_mapping,
                        future_market.slot_trade_mapping]:
-            assert len(buffer.keys()) == 5
+            assert len(buffer.keys()) == 4
             future_time_slot = DEFAULT_CURRENT_MARKET_SLOT.add(
                 minutes=DEFAULT_SLOT_LENGTH.total_minutes())
             most_future_slot = (future_time_slot +
@@ -130,10 +130,10 @@ class TestFutureMarkets:
                           time_slot=time_slot)
             future_market.trades.append(trade)
 
-        count_orders_in_buffers(future_market, 5)
+        count_orders_in_buffers(future_market, 4)
         first_future_market = next(iter(future_market.slot_bid_mapping))
         future_market.delete_orders_in_old_future_markets(first_future_market)
-        count_orders_in_buffers(future_market, 4)
+        count_orders_in_buffers(future_market, 3)
 
     @staticmethod
     def test_offer_is_posted_correctly(future_market):

--- a/tests/market/test_future.py
+++ b/tests/market/test_future.py
@@ -15,6 +15,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from unittest.mock import patch, MagicMock
+
 import pytest
 from gsy_framework.constants_limits import GlobalConfig, DATE_TIME_FORMAT
 from gsy_framework.data_classes import Bid, Offer, Trade, TradeBidOfferInfo
@@ -84,8 +86,28 @@ class TestFutureMarkets:
     """Tests that target the future markets."""
 
     @staticmethod
+    @patch("gsy_e.models.market.future.is_time_slot_in_simulation_duration",
+           MagicMock())
     def test_create_future_markets(future_market):
         """Test if all future time_slots are created in the order buffers."""
+        future_market.offers = {}
+        future_market.bids = {}
+
+        with patch("gsy_e.models.market.future.GlobalConfig."
+                   "FUTURE_MARKET_DURATION_HOURS", 0):
+            future_market.create_future_markets(
+                DEFAULT_CURRENT_MARKET_SLOT, DEFAULT_SLOT_LENGTH, MagicMock()
+            )
+        for buffer in [future_market.slot_bid_mapping,
+                       future_market.slot_offer_mapping,
+                       future_market.slot_trade_mapping]:
+            assert len(buffer.keys()) == 0
+
+        with patch("gsy_e.models.market.future.GlobalConfig."
+                   "FUTURE_MARKET_DURATION_HOURS", 1):
+            future_market.create_future_markets(
+                DEFAULT_CURRENT_MARKET_SLOT, DEFAULT_SLOT_LENGTH, MagicMock()
+            )
         for buffer in [future_market.slot_bid_mapping,
                        future_market.slot_offer_mapping,
                        future_market.slot_trade_mapping]:


### PR DESCRIPTION
2 Bugs were fixed in context of this PR

1. When the `FUTURE_MARKETS_DURATION_HOURS` == 0, we shouldn't create any future market but in reality, we were.
2. We were prolonging the future time slots starting from the first future market, which is not correct, for instance: FUTURE_MARKETS_DURATION_HOURS = 1, current_time_slot = 00:00:00, future_time_slot = 00:15:00, we were assigning the most_future_slot to be equal to 1 hour from the 00:15:00 slot -> 01:15:00, whereas it should be 01:00:00