### PR TITLE
Pin Kafka to the last version without permission issues

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     # See https://rmoff.net/2018/08/02/kafka-listeners-explained/ for details
     # "`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-
     #
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.0.0
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
Building the Kafka container fails with 
> Command [/usr/local/bin/dub path /etc/kafka/ writable] FAILED !

This issue was introduced by the recent `7.0.1` release. This PR pins our Kafka image version to `7.0.0`.

## Reference

- https://github.com/confluentinc/kafka-images/issues/127