### PR TITLE
GSYE-95: Update energy requirements for loadhours in future markets

### DIFF
--- a/src/gsy_e/models/area/event_dispatcher.py
+++ b/src/gsy_e/models/area/event_dispatcher.py
@@ -223,7 +223,8 @@ class AreaDispatcher:
     @staticmethod
     def _create_agent_object(owner: "Area", higher_market: MarketBase,
                              lower_market: MarketBase, market_type: AvailableMarketTypes
-                             ) -> Union[OneSidedAgent, SettlementAgent, BalancingAgent]:
+                             ) -> Union[OneSidedAgent, SettlementAgent,
+                                        BalancingAgent, FutureAgent]:
         agent_constructor_arguments = {
             "owner": owner,
             "higher_market": higher_market,
@@ -325,6 +326,8 @@ class AreaDispatcher:
         self._delete_past_agents(self._spot_agents)
         self._delete_past_agents(self._balancing_agents)
         self._delete_past_agents(self._settlement_agents)
+        if self._future_agent:
+            self._future_agent.delete_engines()
 
     def _delete_past_agents(
             self, market_agent_member: Dict[DateTime, Union[

--- a/src/gsy_e/models/market/future.py
+++ b/src/gsy_e/models/market/future.py
@@ -207,7 +207,8 @@ class FutureMarkets(TwoSidedMarket):
                                         "method in future markets.")
         bid = super().bid(price=price, energy=energy, buyer=buyer, buyer_origin=buyer_origin,
                           bid_id=bid_id, original_price=original_price,
-                          add_to_history=True, adapt_price_with_fees=adapt_price_with_fees,
+                          add_to_history=add_to_history,
+                          adapt_price_with_fees=adapt_price_with_fees,
                           buyer_origin_id=buyer_origin_id, buyer_id=buyer_id,
                           attributes=attributes, requirements=requirements, time_slot=time_slot)
         return bid

--- a/src/gsy_e/models/market/future.py
+++ b/src/gsy_e/models/market/future.py
@@ -205,7 +205,7 @@ class FutureMarkets(TwoSidedMarket):
                                         "method in future markets.")
         bid = super().bid(price=price, energy=energy, buyer=buyer, buyer_origin=buyer_origin,
                           bid_id=bid_id, original_price=original_price,
-                          add_to_history=False, adapt_price_with_fees=adapt_price_with_fees,
+                          add_to_history=True, adapt_price_with_fees=adapt_price_with_fees,
                           buyer_origin_id=buyer_origin_id, buyer_id=buyer_id,
                           attributes=attributes, requirements=requirements, time_slot=time_slot)
         return bid

--- a/src/gsy_e/models/market/one_sided.py
+++ b/src/gsy_e/models/market/one_sided.py
@@ -329,7 +329,7 @@ class OneSidedMarket(MarketBase):
         if already_tracked is False:
             self._update_stats_after_trade(trade, offer)
             log.info(f"{self._debug_log_market_type_identifier}[TRADE][OFFER] "
-                     f"[{self.name}] [{self.time_slot_str}] {trade}")
+                     f"[{self.name}] [{trade.time_slot}] {trade}")
 
         # TODO: Use non-blockchain non-event-driven version for now for both blockchain and
         # normal runs.

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -260,7 +260,7 @@ class TwoSidedMarket(OneSidedMarket):
         if already_tracked is False:
             self._update_stats_after_trade(trade, bid, already_tracked)
             log.info(f"{self._debug_log_market_type_identifier}[TRADE][BID] [{self.name}] "
-                     f"[{self.time_slot_str}] {trade}")
+                     f"[{trade.time_slot}] {trade}")
 
         self._notify_listeners(MarketEvent.BID_TRADED, bid_trade=trade)
         return trade

--- a/src/gsy_e/models/strategy/external_strategies/load.py
+++ b/src/gsy_e/models/strategy/external_strategies/load.py
@@ -51,7 +51,7 @@ class LoadExternalMixin(ExternalMixin):
     posted_bid_energy: Callable
     _delete_past_state: Callable
     _calculate_active_markets: Callable
-    _update_energy_requirement_spot_market: Callable
+    _update_energy_requirement_in_state: Callable
 
     @property
     def channel_dict(self) -> Dict:
@@ -239,7 +239,7 @@ class LoadExternalMixin(ExternalMixin):
         if not self.should_use_default_strategy:
             self.add_entry_in_hrs_per_day()
             self._calculate_active_markets()
-            self._update_energy_requirement_spot_market()
+            self._update_energy_requirement_in_state()
             self._set_energy_measurement_of_last_market()
             if not self.is_aggregator_controlled:
                 market_event_channel = f"{self.channel_prefix}/events/market"
@@ -445,7 +445,7 @@ class LoadForecastExternalStrategy(ForecastExternalMixin, LoadProfileExternalStr
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
 
-    def _update_energy_requirement_spot_market(self):
+    def _update_energy_requirement_in_state(self):
         """
         Setting demanded energy for the next slot is already done by update_energy_forecast
         """

--- a/src/gsy_e/models/strategy/external_strategies/load.py
+++ b/src/gsy_e/models/strategy/external_strategies/load.py
@@ -51,7 +51,7 @@ class LoadExternalMixin(ExternalMixin):
     posted_bid_energy: Callable
     _delete_past_state: Callable
     _calculate_active_markets: Callable
-    _update_energy_requirement_future_markets: Callable
+    _update_energy_requirement_spot_market: Callable
 
     @property
     def channel_dict(self) -> Dict:
@@ -239,7 +239,7 @@ class LoadExternalMixin(ExternalMixin):
         if not self.should_use_default_strategy:
             self.add_entry_in_hrs_per_day()
             self._calculate_active_markets()
-            self._update_energy_requirement_future_markets()
+            self._update_energy_requirement_spot_market()
             self._set_energy_measurement_of_last_market()
             if not self.is_aggregator_controlled:
                 market_event_channel = f"{self.channel_prefix}/events/market"
@@ -445,7 +445,7 @@ class LoadForecastExternalStrategy(ForecastExternalMixin, LoadProfileExternalStr
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
 
-    def _update_energy_requirement_future_markets(self):
+    def _update_energy_requirement_spot_market(self):
         """
         Setting demanded energy for the next slot is already done by update_energy_forecast
         """

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 from logging import getLogger
 from typing import Union, Dict, List  # NOQA
 
-from gsy_framework.constants_limits import ConstSettings
+from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.data_classes import Offer
 from gsy_framework.enums import SpotMarketTypeEnum
 from gsy_framework.exceptions import GSyDeviceException
@@ -178,7 +178,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
         if ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.ONE_SIDED.value:
             self.bid_update.reset(self)
         self._calculate_active_markets()
-        self._update_energy_requirement_future_markets()
+        self._update_energy_requirement_spot_market()
         # Provide energy values for the past market slot, to be used in the settlement market
         self._set_energy_measurement_of_last_market()
         self._set_alternative_pricing_scheme()
@@ -275,7 +275,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
             self.add_entry_in_hrs_per_day(overwrite=True)
         if kwargs.get("avg_power_W") is not None:
             self.avg_power_W = kwargs["avg_power_W"]
-            self._update_energy_requirement_future_markets()
+            self._update_energy_requirement_spot_market()
         self._area_reconfigure_prices(**kwargs)
         self.bid_update.update_and_populate_price_settings(self.area)
 
@@ -471,7 +471,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
         """Update energy requirement upon the activation event."""
         self.hrs_per_day = {0: self._initial_hrs_per_day}
         self._simulation_start_timestamp = self.area.now
-        self._update_energy_requirement_future_markets()
+        self._update_energy_requirement_spot_market()
 
     @property
     def active_markets(self):
@@ -512,12 +512,22 @@ class LoadHoursStrategy(BidEnabledStrategy):
             raise ValueError("Length of list 'hrs_of_day' must be greater equal 'hrs_per_day'")
 
     def _update_energy_requirement_future_markets(self):
+        if not GlobalConfig.FUTURE_MARKET_DURATION_HOURS:
+            return
+        for time_slot in self.area.future_market_time_slots:
+            desired_energy_Wh = (
+                self.energy_per_slot_Wh
+                if self._allowed_operating_hours(time_slot) else 0.0)
+            self.state.set_desired_energy(desired_energy_Wh, time_slot, overwrite=True)
+
+    def _update_energy_requirement_spot_market(self):
         self.energy_per_slot_Wh = convert_W_to_Wh(
             self.avg_power_W, self.simulation_config.slot_length)
         desired_energy_Wh = (self.energy_per_slot_Wh
                              if self._allowed_operating_hours(self.area.spot_market.time_slot)
                              else 0.0)
-        self.state.set_desired_energy(desired_energy_Wh, self.area.spot_market.time_slot)
+        self.state.set_desired_energy(desired_energy_Wh,
+                                      self.area.spot_market.time_slot, overwrite=True)
 
         for market in self.active_markets:
             current_day = self._get_day_of_timestamp(market.time_slot)
@@ -528,6 +538,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
                 self.state.set_desired_energy(0.0, market.time_slot, True)
         if self.area.current_market:
             self.state.update_total_demanded_energy(self.area.current_market.time_slot)
+        self._update_energy_requirement_future_markets()
 
     def _allowed_operating_hours(self, time):
         return time.hour in self.hrs_of_day

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -526,7 +526,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
                     desired_energy_Wh = 0.0
             else:
                 desired_energy_Wh = 0.0
-            self.state.set_desired_energy(desired_energy_Wh, time_slot, overwrite=True)
+            self.state.set_desired_energy(desired_energy_Wh, time_slot)
 
     def _update_energy_requirement_in_state(self):
         self._update_energy_requirement_spot_market()
@@ -539,7 +539,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
                              if self._allowed_operating_hours(self.area.spot_market.time_slot)
                              else 0.0)
         self.state.set_desired_energy(desired_energy_Wh,
-                                      self.area.spot_market.time_slot, overwrite=True)
+                                      self.area.spot_market.time_slot)
 
         for market in self.active_markets:
             current_day = self._get_day_of_timestamp(market.time_slot)

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from collections import namedtuple
 from logging import getLogger
-from typing import Union, Dict, List  # NOQA
+from typing import Union, Dict, List, Optional  # NOQA
 
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.data_classes import Offer
@@ -93,10 +93,13 @@ class LoadHoursStrategy(BidEnabledStrategy):
         self.daily_energy_required = None
         # Energy consumed during the day ideally should not exceed daily_energy_required
         self.energy_per_slot_Wh = None
-        self.hrs_per_day = {}  # type: Dict[int, int]
 
-        self.hrs_of_day = None
-        self._initial_hrs_per_day = None
+        # Maps each simulation day to the number of active hours in that day
+        self.hrs_per_day: Dict[int, int] = {}
+
+        # List of active hours of day (values range from 0 to 23)
+        self.hrs_of_day: Optional[List[int]] = None
+        self._initial_hrs_per_day: Optional[int] = None
         self.assign_hours_of_per_day(hrs_of_day, hrs_per_day)
         self.balancing_energy_ratio = BalancingRatio(*balancing_energy_ratio)
         self.use_market_maker_rate = use_market_maker_rate
@@ -493,8 +496,8 @@ class LoadHoursStrategy(BidEnabledStrategy):
                 (not self.area.current_market or
                  market.time_slot >= self.area.current_market.time_slot))
 
-    def assign_hours_of_per_day(self, hrs_of_day: List[int], hrs_per_day: List[int]):
-        """Validate and assign the values of hrs_of_day and hrs_per_day."""
+    def assign_hours_of_per_day(self, hrs_of_day: List[int], hrs_per_day: int):
+        """Validate and assign the values of hrs_of_day and _initial_hrs_per_day."""
         if hrs_of_day is None:
             hrs_of_day = list(range(24))
 

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -178,7 +178,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
         if ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.ONE_SIDED.value:
             self.bid_update.reset(self)
         self._calculate_active_markets()
-        self._update_energy_requirement_spot_market()
+        self._update_energy_requirement_in_state()
         # Provide energy values for the past market slot, to be used in the settlement market
         self._set_energy_measurement_of_last_market()
         self._set_alternative_pricing_scheme()
@@ -275,7 +275,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
             self.add_entry_in_hrs_per_day(overwrite=True)
         if kwargs.get("avg_power_W") is not None:
             self.avg_power_W = kwargs["avg_power_W"]
-            self._update_energy_requirement_spot_market()
+            self._update_energy_requirement_in_state()
         self._area_reconfigure_prices(**kwargs)
         self.bid_update.update_and_populate_price_settings(self.area)
 
@@ -471,7 +471,7 @@ class LoadHoursStrategy(BidEnabledStrategy):
         """Update energy requirement upon the activation event."""
         self.hrs_per_day = {0: self._initial_hrs_per_day}
         self._simulation_start_timestamp = self.area.now
-        self._update_energy_requirement_spot_market()
+        self._update_energy_requirement_in_state()
 
     @property
     def active_markets(self):
@@ -515,10 +515,19 @@ class LoadHoursStrategy(BidEnabledStrategy):
         if not GlobalConfig.FUTURE_MARKET_DURATION_HOURS:
             return
         for time_slot in self.area.future_market_time_slots:
-            desired_energy_Wh = (
-                self.energy_per_slot_Wh
-                if self._allowed_operating_hours(time_slot) else 0.0)
+            if self._allowed_operating_hours(time_slot):
+                current_day = self._get_day_of_timestamp(time_slot)
+                desired_energy_Wh = self.energy_per_slot_Wh
+                if (current_day not in self.hrs_per_day or
+                        self.hrs_per_day[current_day] <= FLOATING_POINT_TOLERANCE):
+                    desired_energy_Wh = 0.0
+            else:
+                desired_energy_Wh = 0.0
             self.state.set_desired_energy(desired_energy_Wh, time_slot, overwrite=True)
+
+    def _update_energy_requirement_in_state(self):
+        self._update_energy_requirement_spot_market()
+        self._update_energy_requirement_future_markets()
 
     def _update_energy_requirement_spot_market(self):
         self.energy_per_slot_Wh = convert_W_to_Wh(

--- a/src/gsy_e/models/strategy/market_agents/future_agent.py
+++ b/src/gsy_e/models/strategy/market_agents/future_agent.py
@@ -57,7 +57,3 @@ class FutureAgent(TwoSidedAgent):
             return
         for engine in self.engines:
             engine.clean_up_order_buffers(self.owner.current_market.time_slot)
-
-    def event_market_cycle(self):
-        super().event_market_cycle()
-        self.delete_engines()

--- a/src/gsy_e/models/strategy/predefined_load.py
+++ b/src/gsy_e/models/strategy/predefined_load.py
@@ -124,7 +124,7 @@ class DefinedLoadStrategy(LoadHoursStrategy):
                 f"without a profile.")
         load_energy_kWh = \
             find_object_of_same_weekday_and_time(self._load_profile_kWh, slot_time)
-        self.state.set_desired_energy(load_energy_kWh * 1000, slot_time, overwrite=True)
+        self.state.set_desired_energy(load_energy_kWh * 1000, slot_time, overwrite=False)
         self.state.update_total_demanded_energy(slot_time)
         self._update_energy_requirement_future_markets()
 
@@ -135,7 +135,7 @@ class DefinedLoadStrategy(LoadHoursStrategy):
                 find_object_of_same_weekday_and_time(
                     self._load_profile_kWh, time_slot))
             self.state.set_desired_energy(
-                load_energy_kWh * 1000, time_slot, overwrite=True)
+                load_energy_kWh * 1000, time_slot, overwrite=False)
             self.state.update_total_demanded_energy(time_slot)
 
     def _operating_hours(self, energy_kWh):

--- a/src/gsy_e/models/strategy/predefined_load.py
+++ b/src/gsy_e/models/strategy/predefined_load.py
@@ -110,7 +110,7 @@ class DefinedLoadStrategy(LoadHoursStrategy):
         self._read_or_rotate_profiles()
         super().event_market_cycle()
 
-    def _update_energy_requirement_future_markets(self):
+    def _update_energy_requirement_spot_market(self):
         """
         Update required energy values for each market slot.
         :return: None
@@ -126,6 +126,17 @@ class DefinedLoadStrategy(LoadHoursStrategy):
             find_object_of_same_weekday_and_time(self._load_profile_kWh, slot_time)
         self.state.set_desired_energy(load_energy_kWh * 1000, slot_time, overwrite=False)
         self.state.update_total_demanded_energy(slot_time)
+        self._update_energy_requirement_future_markets()
+
+    def _update_energy_requirement_future_markets(self):
+        """Update energy requirements in the future markets."""
+        for time_slot in self.area.future_market_time_slots:
+            load_energy_kWh = (
+                find_object_of_same_weekday_and_time(
+                    self._load_profile_kWh, time_slot))
+            self.state.set_desired_energy(
+                load_energy_kWh * 1000, time_slot, overwrite=False)
+            self.state.update_total_demanded_energy(time_slot)
 
     def _operating_hours(self, energy_kWh):
         """

--- a/src/gsy_e/models/strategy/predefined_load.py
+++ b/src/gsy_e/models/strategy/predefined_load.py
@@ -124,7 +124,7 @@ class DefinedLoadStrategy(LoadHoursStrategy):
                 f"without a profile.")
         load_energy_kWh = \
             find_object_of_same_weekday_and_time(self._load_profile_kWh, slot_time)
-        self.state.set_desired_energy(load_energy_kWh * 1000, slot_time, overwrite=False)
+        self.state.set_desired_energy(load_energy_kWh * 1000, slot_time, overwrite=True)
         self.state.update_total_demanded_energy(slot_time)
         self._update_energy_requirement_future_markets()
 
@@ -135,7 +135,7 @@ class DefinedLoadStrategy(LoadHoursStrategy):
                 find_object_of_same_weekday_and_time(
                     self._load_profile_kWh, time_slot))
             self.state.set_desired_energy(
-                load_energy_kWh * 1000, time_slot, overwrite=False)
+                load_energy_kWh * 1000, time_slot, overwrite=True)
             self.state.update_total_demanded_energy(time_slot)
 
     def _operating_hours(self, energy_kWh):

--- a/tests/strategies/market_agents/test_future_agent.py
+++ b/tests/strategies/market_agents/test_future_agent.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from typing import Generator
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from gsy_framework.constants_limits import GlobalConfig
@@ -48,12 +48,3 @@ class TestFutureAgent:
         """Test whether __init__ creates list of engines off type FutureEngine."""
         for engine in future_agent.engines:
             assert isinstance(engine, FutureEngine)
-
-    @staticmethod
-    def test_event_market_cycle_calls_engine_clean_up_buffers(future_agent: FutureAgent) -> None:
-        """Test whether event_market_cycle calls clean_up_buffers of all engines."""
-        for engine in future_agent.engines:
-            engine.clean_up_order_buffers = Mock()
-        future_agent.event_market_cycle()
-        for engine in future_agent.engines:
-            engine.clean_up_order_buffers.assert_called_once()

--- a/tests/strategies/test_strategy_load_hours.py
+++ b/tests/strategies/test_strategy_load_hours.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 
 import pytest
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
+from gsy_framework.data_classes import Offer, BalancingOffer, Bid, Trade
 from gsy_framework.enums import SpotMarketTypeEnum
 from gsy_framework.exceptions import GSyDeviceException
 from pendulum import DateTime, duration, today, now
@@ -32,7 +33,6 @@ from gsy_e.constants import TIME_ZONE, TIME_FORMAT
 from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.gsy_e_core.util import d3a_path
 from gsy_e.models.area import DEFAULT_CONFIG, Area
-from gsy_framework.data_classes import Offer, BalancingOffer, Bid, Trade
 from gsy_e.models.strategy.load_hours import LoadHoursStrategy
 from gsy_e.models.strategy.predefined_load import DefinedLoadStrategy
 
@@ -73,6 +73,10 @@ class FakeArea:
     @property
     def future_markets(self):
         return None
+
+    @property
+    def future_market_time_slots(self):
+        return []
 
     @property
     def all_markets(self):
@@ -592,10 +596,10 @@ def test_assert_if_trade_rate_is_higher_than_bid_rate(load_hours_strategy_test3)
 def test_event_market_cycle_updates_measurement_and_forecast(load_hours_strategy_test1):
     """update_state sends command to update the simulated real energy of the device."""
     load_hours_strategy_test1._set_energy_measurement_of_last_market = Mock()
-    load_hours_strategy_test1._update_energy_requirement_future_markets = Mock()
+    load_hours_strategy_test1._update_energy_requirement_spot_market = Mock()
     load_hours_strategy_test1.event_market_cycle()
     load_hours_strategy_test1._set_energy_measurement_of_last_market.assert_called_once()
-    load_hours_strategy_test1._update_energy_requirement_future_markets.assert_called_once()
+    load_hours_strategy_test1._update_energy_requirement_spot_market.assert_called_once()
 
 
 @patch("gsy_e.models.strategy.load_hours.utils")

--- a/tests/strategies/test_strategy_load_hours.py
+++ b/tests/strategies/test_strategy_load_hours.py
@@ -596,10 +596,10 @@ def test_assert_if_trade_rate_is_higher_than_bid_rate(load_hours_strategy_test3)
 def test_event_market_cycle_updates_measurement_and_forecast(load_hours_strategy_test1):
     """update_state sends command to update the simulated real energy of the device."""
     load_hours_strategy_test1._set_energy_measurement_of_last_market = Mock()
-    load_hours_strategy_test1._update_energy_requirement_spot_market = Mock()
+    load_hours_strategy_test1._update_energy_requirement_in_state = Mock()
     load_hours_strategy_test1.event_market_cycle()
     load_hours_strategy_test1._set_energy_measurement_of_last_market.assert_called_once()
-    load_hours_strategy_test1._update_energy_requirement_spot_market.assert_called_once()
+    load_hours_strategy_test1._update_energy_requirement_in_state.assert_called_once()
 
 
 @patch("gsy_e.models.strategy.load_hours.utils")

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps =
 	coverage
 commands =
 	python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    pip-sync requirements/tests.txt requirements/pandapower.txt
+    pip-sync requirements/tests.txt
     pip install -e .
 	pip uninstall -y gsy-framework
 	pip install git+https://github.com/gridsingularity/gsy-framework@{env:BRANCH:master}

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps =
 	coverage
 commands =
 	python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    pip-sync requirements/tests.txt
+    pip-sync requirements/tests.txt requirements/pandapower.txt
     pip install -e .
 	pip uninstall -y gsy-framework
 	pip install git+https://github.com/gridsingularity/gsy-framework@{env:BRANCH:master}


### PR DESCRIPTION
[LoadHoursStrategy]: The energy requirements of future time slots were not getting updated as they were supposed to be .this is why they were not placing bids in the future markets, this PR adds support for this functionality