### PR TITLE
Fix bumpversion replacement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ tag = True
 
 [bumpversion:file:setup.py]
 search = VERSION = "{current_version}"
+replace = VERSION = "{new_version}"
 
 [wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ universal = 1
 
 [isort]
 line_length = 99
-known_first_party = d3a
+known_first_party = gsy_e
 
 [captainhook]
 flake8 = on


### PR DESCRIPTION
Allow using bumpversion in this repository, without needing to manually add the tag.