### PR TITLE
Bug/gsye 123

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -477,7 +477,7 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_
+no-docstring-rgx=^_|^test_|^Test|^step_impl|^setup_method|^teardown_method
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.

--- a/src/gsy_e/models/myco_matcher/myco_external_matcher.py
+++ b/src/gsy_e/models/myco_matcher/myco_external_matcher.py
@@ -150,6 +150,7 @@ class MycoExternalMatcher(MycoMatcherInterface):
         if response_data["status"] != "success":
             logging.debug("All recommendations failed: %s", response_data)
             self.myco_ext_conn.publish_json(channel, response_data)
+            self._recommendations = []
             return
 
         for recommendation in response_data["recommendations"]:

--- a/tests/market/test_market_redis_connection.py
+++ b/tests/market/test_market_redis_connection.py
@@ -1,18 +1,18 @@
+# pylint: disable=protected-access
 import json
 import unittest
-from concurrent.futures import Future
-from time import sleep
+from concurrent.futures import Future, wait
 from unittest.mock import MagicMock
 
-from gsy_framework.constants_limits import ConstSettings
 from deepdiff import DeepDiff
+from gsy_framework.constants_limits import ConstSettings
+from gsy_framework.data_classes import Offer, Trade, Bid
 from pendulum import now, datetime
 
 import gsy_e.models.market.market_redis_connection
 from gsy_e.events import MarketEvent
-from gsy_e.models.market.market_redis_connection import MarketRedisEventPublisher, \
-    MarketRedisEventSubscriber, TwoSidedMarketRedisEventSubscriber
-from gsy_framework.data_classes import Offer, Trade, Bid
+from gsy_e.models.market.market_redis_connection import (
+    MarketRedisEventPublisher, MarketRedisEventSubscriber, TwoSidedMarketRedisEventSubscriber)
 from gsy_e.models.market.one_sided import OneSidedMarket
 
 gsy_e.models.market.market_redis_connection.BlockingCommunicator = MagicMock
@@ -141,7 +141,7 @@ class TestMarketRedisEventSubscriber(unittest.TestCase):
                       seller="trade_seller", buyer="trade_buyer")
         self.market.accept_offer = MagicMock(return_value=trade)
         self.subscriber._accept_offer(payload)
-        sleep(0.1)
+        wait(self.subscriber.futures)
         self.subscriber.market.accept_offer.assert_called_once_with(
             offer_or_id=offer, buyer="mykonos", energy=12
         )
@@ -163,7 +163,7 @@ class TestMarketRedisEventSubscriber(unittest.TestCase):
         offer = Offer("o_id", now(), 32, 12, "o_seller")
         self.market.offer = MagicMock(return_value=offer)
         self.subscriber._offer(payload)
-        sleep(0.01)
+        wait(self.subscriber.futures)
         self.subscriber.market.offer.assert_called_once_with(
             seller="mykonos", energy=12, price=32
         )
@@ -183,6 +183,7 @@ class TestMarketRedisEventSubscriber(unittest.TestCase):
 
         self.market.delete_offer = MagicMock(return_value=offer)
         self.subscriber._delete_offer(payload)
+        wait(self.subscriber.futures)
         self.subscriber.market.delete_offer.assert_called_once_with(
             offer_or_id=offer
         )
@@ -228,7 +229,7 @@ class TestTwoSidedMarketRedisEventSubscriber(unittest.TestCase):
                       seller="trade_seller", buyer="trade_buyer")
         self.market.accept_bid = MagicMock(return_value=trade)
         self.subscriber._accept_bid(payload)
-        sleep(.3)
+        wait(self.subscriber.futures)
         self.subscriber.market.accept_bid.assert_called_once()
         self.subscriber.redis_db.publish.assert_called_once_with(
             "id/ACCEPT_BID/RESPONSE", json.dumps({
@@ -248,7 +249,7 @@ class TestTwoSidedMarketRedisEventSubscriber(unittest.TestCase):
         bid = Bid("b_id", now(), 32, 12, "b_buyer", "b_seller")
         self.market.bid = MagicMock(return_value=bid)
         self.subscriber._bid(payload)
-        sleep(.3)
+        wait(self.subscriber.futures)
         self.subscriber.market.bid.assert_called_once_with(
             buyer="mykonos", energy=12, price=32
         )
@@ -268,7 +269,7 @@ class TestTwoSidedMarketRedisEventSubscriber(unittest.TestCase):
 
         self.market.delete_bid = MagicMock(return_value=bid)
         self.subscriber._delete_bid(payload)
-        sleep(.3)
+        wait(self.subscriber.futures)
         self.subscriber.market.delete_bid.assert_called_once()
         self.subscriber.redis_db.publish.assert_called_once_with(
             "id/DELETE_BID/RESPONSE",

--- a/tests/market/test_myco_external_matcher.py
+++ b/tests/market/test_myco_external_matcher.py
@@ -156,6 +156,7 @@ class TestMycoExternalMatcher:
             "status": "success", "recommendations": []}
         self.matcher._populate_recommendations(payload)
         self.matcher.match_recommendations()
+        assert not self.matcher._recommendations
         mock_market_match_recommendations.assert_not_called()
         self.matcher.myco_ext_conn.publish_json.assert_not_called()
 
@@ -167,6 +168,7 @@ class TestMycoExternalMatcher:
         payload = {"data": json.dumps({"recommended_matches": [{}, {}]})}
         self.matcher._populate_recommendations(payload)
         self.matcher.match_recommendations()
+        assert not self.matcher._recommendations
         expected_data = {
             "event": "match", "status": "fail",
             "recommendations": [],
@@ -183,6 +185,7 @@ class TestMycoExternalMatcher:
                                  "time_slot": self.market.time_slot_str}]}
         self.matcher._populate_recommendations(payload)
         self.matcher.match_recommendations()
+        assert not self.matcher._recommendations
         expected_data = {
             "event": "match", "status": "success",
             "recommendations": [{"market_id": self.market_id,

--- a/tests/market/test_myco_external_matcher.py
+++ b/tests/market/test_myco_external_matcher.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 import json
 from unittest.mock import MagicMock, patch
 
@@ -197,9 +198,10 @@ class TestMycoExternalMatcher:
 
 
 class TestMycoExternalMatcherValidator:
+    @staticmethod
     @patch("gsy_e.models.myco_matcher.myco_external_matcher.MycoExternalMatcherValidator."
            "_validate")
-    def test_validate_and_report(self, mock_validate):
+    def test_validate_and_report(mock_validate):
         recommendations = []
         expected_data = {"status": "success", "recommendations": []}
         assert MycoExternalMatcherValidator.validate_and_report(
@@ -234,8 +236,9 @@ class TestMycoExternalMatcherValidator:
         assert MycoExternalMatcherValidator.validate_and_report(
             None, recommendations) == expected_data
 
+    @staticmethod
     @patch("gsy_e.models.myco_matcher.myco_external_matcher.BidOfferMatch.is_valid_dict")
-    def test_validate_valid_dict(self, mock_is_valid_dict):
+    def test_validate_valid_dict(mock_is_valid_dict):
         mock_is_valid_dict.return_value = True
         assert MycoExternalMatcherValidator._validate_valid_dict(None, {}) is None
 
@@ -243,8 +246,9 @@ class TestMycoExternalMatcherValidator:
         with pytest.raises(MycoValidationException):
             MycoExternalMatcherValidator._validate_valid_dict(None, {})
 
+    @staticmethod
     @patch("gsy_e.models.myco_matcher.myco_external_matcher.MycoExternalMatcher")
-    def test_validate_market_exists(self, mock_myco_external_matcher):
+    def test_validate_market_exists(mock_myco_external_matcher):
         market = MagicMock()
         market.time_slot_str = "2021-10-06T12:00"
         mock_myco_external_matcher.area_markets_mapping = {"market-2021-10-06T12:00": market}
@@ -257,8 +261,9 @@ class TestMycoExternalMatcherValidator:
             MycoExternalMatcherValidator._validate_market_exists(
                 mock_myco_external_matcher, recommendation)
 
+    @staticmethod
     @patch("gsy_e.models.myco_matcher.myco_external_matcher.MycoExternalMatcher")
-    def test_validate_orders_exist_in_market(self, mock_myco_external_matcher):
+    def test_validate_orders_exist_in_market(mock_myco_external_matcher):
         market = MagicMock()
         market.time_slot_str = "2021-10-06T12:00"
         market.offers = {"offer1": MagicMock()}


### PR DESCRIPTION
The root cause of the bug was that the _recommendations buffer on the External Myco Matcher was not cleared under certain occasions (more specifically, when the full recommendation set was rejected for some reason - for instance, when the Myco was not fast enough and was sending recommendations for a market slot after the slot was deleted / replaced with a new one). This had the effect that the buffer was always populated, thus always rejecting any new recommendations that might arrive by the Myco. The fix was to clear the buffer even when the recommendation set was fully rejected.

In the context of the PR, I also added pylint docstring exceptions for test functions and classes. This will be dealt by this ticket for all repos https://gridsingularity.atlassian.net/browse/GSYE-63, however since these Pylint warnings got in the way I added the fix for gsy-e. 

