### PR TITLE
GSYE-109: Send settlement market orders to external myco

### DIFF
--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -454,7 +454,7 @@ class Area:
         bid_offer_matcher.update_area_uuid_markets_mapping(
             area_uuid_markets_mapping={
                 self.uuid: {"markets": [self.spot_market],
-                            "settlement_markets": self.settlement_markets.values(),
+                            "settlement_markets": list(self.settlement_markets.values()),
                             "future_markets": self.future_markets,
                             "current_time": self.now}})
 
@@ -586,6 +586,7 @@ class Area:
         return self._markets.indexed_future_markets.get(_id, None)
 
     def get_spot_or_future_market_by_id(self, market_id: str) -> Optional["MarketBase"]:
+        """Retrieve a spot or future market from its ID."""
         if self.is_market_spot(market_id):
             return self.spot_market
         if self.is_market_future(market_id):
@@ -593,6 +594,7 @@ class Area:
         return None
 
     def is_market_spot_or_future(self, market_id):
+        """Return True if the market is a spot or future market."""
         return self.is_market_spot(market_id) or self.is_market_future(market_id)
 
     @property

--- a/src/gsy_e/models/myco_matcher/myco_external_matcher.py
+++ b/src/gsy_e/models/myco_matcher/myco_external_matcher.py
@@ -99,7 +99,7 @@ class MycoExternalMatcher(MycoMatcherInterface):
                     continue
 
                 # Cache the market (needed while matching)
-                for market in area_data["markets"]:
+                for market in area_data["markets"] + area_data.get("settlement_markets", []):
                     self.area_markets_mapping.update(
                         {f"{area_uuid}-{market.time_slot_str}": market})
                     if area_uuid not in market_orders_list_mapping:
@@ -110,15 +110,6 @@ class MycoExternalMatcher(MycoMatcherInterface):
                 if area_data.get("future_markets"):
                     # Future markets
                     market = area_data["future_markets"]
-                    self.area_markets_mapping.update(
-                        {f"{area_uuid}-{time_slot_str}": market
-                         for time_slot_str in market.orders_per_slot().keys()})
-                    if area_uuid not in market_orders_list_mapping:
-                        market_orders_list_mapping[area_uuid] = {}
-                    market_orders_list_mapping[area_uuid].update(
-                        self._get_orders(market, filters))
-
-                for market in area_data.get("settlement_markets", []):
                     self.area_markets_mapping.update(
                         {f"{area_uuid}-{time_slot_str}": market
                          for time_slot_str in market.orders_per_slot().keys()})

--- a/src/gsy_e/models/myco_matcher/myco_external_matcher.py
+++ b/src/gsy_e/models/myco_matcher/myco_external_matcher.py
@@ -97,6 +97,7 @@ class MycoExternalMatcher(MycoMatcherInterface):
                 if filtered_areas_uuids and area_uuid not in filtered_areas_uuids:
                     # Client is uninterested in this Area -> skip
                     continue
+
                 # Cache the market (needed while matching)
                 for market in area_data["markets"]:
                     self.area_markets_mapping.update(
@@ -116,6 +117,16 @@ class MycoExternalMatcher(MycoMatcherInterface):
                         market_orders_list_mapping[area_uuid] = {}
                     market_orders_list_mapping[area_uuid].update(
                         self._get_orders(market, filters))
+
+                for market in area_data.get("settlement_markets", []):
+                    self.area_markets_mapping.update(
+                        {f"{area_uuid}-{time_slot_str}": market
+                         for time_slot_str in market.orders_per_slot().keys()})
+                    if area_uuid not in market_orders_list_mapping:
+                        market_orders_list_mapping[area_uuid] = {}
+                    market_orders_list_mapping[area_uuid].update(
+                        self._get_orders(market, filters))
+
             self.area_uuid_markets_mapping = {}
             # TODO: change the `bids_offers` key and the channel to `orders`
             response_data.update({


### PR DESCRIPTION
Enable the external matching for orders in settlement markets. The `"settlement_markets"` content was already available to the external myco matcher, but it wasn't being used to send orders to the myco SDK.