### PR TITLE
GSYE-108: Remove loss per hours mechanism in storage assets

### DIFF
--- a/src/gsy_e/models/state.py
+++ b/src/gsy_e/models/state.py
@@ -646,10 +646,6 @@ class StorageState(StateInterface):
         assert 0 <= limit_float_precision(self.pledged_buy_kWh[time_slot]) <= max_value
         assert 0 <= limit_float_precision(self.offered_buy_kWh[time_slot]) <= max_value
 
-    def tick(self, area, time_slot: DateTime) -> None:
-        """Handler for the tick event."""
-        self.check_state(time_slot)
-
     def calculate_soc_for_time_slot(self, time_slot: DateTime) -> None:
         """Update the soc history for the passed time_slot."""
         self.charge_history[time_slot] = 100.0 * self.used_storage / self.capacity

--- a/src/gsy_e/models/strategy/external_strategies/storage.py
+++ b/src/gsy_e/models/strategy/external_strategies/storage.py
@@ -441,7 +441,7 @@ class StorageExternalMixin(ExternalMixin):
         if not self.connected and not self.is_aggregator_controlled:
             super().event_tick()
         else:
-            self.state.tick(self.area, self.spot_market.time_slot)
+            self.state.check_state(self.spot_market.time_slot)
             self.state.clamp_energy_to_sell_kWh([self.spot_market.time_slot])
             self.state.clamp_energy_to_buy_kWh([self.spot_market.time_slot])
 

--- a/src/gsy_e/models/strategy/storage.py
+++ b/src/gsy_e/models/strategy/storage.py
@@ -73,8 +73,6 @@ class StorageStrategy(BidEnabledStrategy):
         StorageSettings.BUYING_RATE_RANGE.initial,
         final_buying_rate: Union[float, dict] =
         StorageSettings.BUYING_RATE_RANGE.final,
-        loss_per_hour=StorageSettings.LOSS_PER_HOUR,
-        loss_function=StorageSettings.LOSS_FUNCTION,
         fit_to_limit=True, energy_rate_increase_per_update=None,
         energy_rate_decrease_per_update=None,
         update_interval=None,
@@ -94,8 +92,6 @@ class StorageStrategy(BidEnabledStrategy):
             initial_soc=initial_soc, min_allowed_soc=min_allowed_soc,
             battery_capacity_kWh=battery_capacity_kWh,
             max_abs_battery_power_kW=max_abs_battery_power_kW,
-            loss_per_hour=loss_per_hour,
-            loss_function=loss_function,
             fit_to_limit=fit_to_limit,
             energy_rate_increase_per_update=energy_rate_increase_per_update,
             energy_rate_decrease_per_update=energy_rate_decrease_per_update)
@@ -129,7 +125,6 @@ class StorageStrategy(BidEnabledStrategy):
         self._state = StorageState(
             initial_soc=initial_soc, initial_energy_origin=initial_energy_origin,
             capacity=battery_capacity_kWh, max_abs_battery_power_kW=max_abs_battery_power_kW,
-            loss_per_hour=loss_per_hour, loss_function=loss_function,
             min_allowed_soc=min_allowed_soc)
         self.cap_price_strategy = cap_price_strategy
         self.balancing_energy_ratio = BalancingRatio(*balancing_energy_ratio)

--- a/src/gsy_e/models/strategy/storage.py
+++ b/src/gsy_e/models/strategy/storage.py
@@ -353,7 +353,7 @@ class StorageStrategy(BidEnabledStrategy):
         market = self.area.spot_market
         self._buy_energy_two_sided_spot_market()
 
-        self.state.tick(self.area, market.time_slot)
+        self.state.check_state(market.time_slot)
         if self.cap_price_strategy is False:
             self.offer_update.update(market, self)
 

--- a/src/gsy_e/setup/gsy_e_settings.json
+++ b/src/gsy_e/setup/gsy_e_settings.json
@@ -4,7 +4,7 @@
     "slot_length": "15m",
     "tick_length": "15s",
     "cloud_coverage": 0,
-    "start_date": "2021-11-19"
+    "start_date": "2022-01-12"
   },
   "advanced_settings": {
     "GeneralSettings": {
@@ -105,21 +105,7 @@
         0,
         10000
       ],
-      "MIN_ALLOWED_SOC": 10,
-      "LOSS_FUNCTION": 1,
-      "LOSS_FUNCTION_LIMIT": [
-        1,
-        2
-      ],
-      "LOSS_PER_HOUR": 0,
-      "LOSS_PER_HOUR_ABSOLUTE_LIMIT": [
-        0,
-        10000
-      ],
-      "LOSS_PER_HOUR_RELATIVE_LIMIT": [
-        0,
-        1
-      ]
+      "MIN_ALLOWED_SOC": 10
     },
     "LoadSettings": {
       "AVG_POWER_LIMIT": [
@@ -173,7 +159,7 @@
       "DEFAULT_POWER_PROFILE": 0,
       "CLOUD_COVERAGE_LIMIT": [
         0,
-        4
+        5
       ],
       "DEFAULT_CAPACITY_KW": 5,
       "MAX_PANEL_OUTPUT_W": 160,


### PR DESCRIPTION
The "loss per hour" mechanism was used to gradually reduce the energy stored by storage assets. Since this mechanism is generating issues and users have no control over it, we are deprecating it. 
We might think of re-introducing it in the future if a good use-case scenario for it will arise.