### PR TITLE
Bug/gsye 117 dispatcher

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -477,7 +477,7 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_|^test_|^Test|^step_impl|^setup_method|^teardown_method
+no-docstring-rgx=^_|^test_|^Test|^step_impl|^setup_method|^teardown_method|^get_setup
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.

--- a/src/gsy_e/models/area/event_dispatcher.py
+++ b/src/gsy_e/models/area/event_dispatcher.py
@@ -115,8 +115,8 @@ class AreaDispatcher:
             self, agent_area: "Area", market_type: AvailableMarketTypes,
             event_type: AreaEvent, **kwargs) -> None:
 
-        if market_type == AvailableMarketTypes.FUTURE and self.future_agent:
-            self.future_agent.event_listener(event_type, **kwargs)
+        if market_type == AvailableMarketTypes.FUTURE and agent_area.dispatcher.future_agent:
+            agent_area.dispatcher.future_agent.event_listener(event_type, **kwargs)
         elif market_type != AvailableMarketTypes.FUTURE:
             agent_dict = self._get_agents_for_market_type(agent_area.dispatcher, market_type)
             for time_slot, agent in agent_dict.items():

--- a/src/gsy_e/models/state.py
+++ b/src/gsy_e/models/state.py
@@ -23,8 +23,8 @@ from typing import Dict, Optional, List
 
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.utils import (
-    convert_pendulum_to_str_in_dict, convert_str_to_pendulum_in_dict, convert_kW_to_kWh)
-from gsy_framework.utils import limit_float_precision
+    convert_pendulum_to_str_in_dict, convert_str_to_pendulum_in_dict, convert_kW_to_kWh,
+    limit_float_precision)
 from pendulum import DateTime
 
 from gsy_e.constants import FLOATING_POINT_TOLERANCE
@@ -541,15 +541,6 @@ class StorageState(StateInterface):
         """
         return self._used_storage
 
-    def update_used_storage_share(self, energy: float, source=ESSEnergyOrigin.UNKNOWN) -> None:
-        """Add an EnergyOrigin instance to the _used_storage_share list."""
-        self._used_storage_share.append(EnergyOrigin(source, energy))
-
-    @property
-    def get_used_storage_share(self) -> List:
-        """Return the _used_storage_share list."""
-        return self._used_storage_share
-
     def free_storage(self, time_slot):
         """
         Storage, that has not been promised or occupied
@@ -559,12 +550,12 @@ class StorageState(StateInterface):
                   + self.pledged_buy_kWh[time_slot])
         return self.capacity - in_use
 
-    def max_offer_energy_kWh(self, time_slot: DateTime) -> float:
+    def _max_offer_energy_kWh(self, time_slot: DateTime) -> float:
         """Return the max tracked offered energy."""
         return (self._battery_energy_per_slot - self.pledged_sell_kWh[time_slot]
                 - self.offered_sell_kWh[time_slot])
 
-    def max_buy_energy_kWh(self, time_slot: DateTime) -> float:
+    def _max_buy_energy_kWh(self, time_slot: DateTime) -> float:
         """Return the min tracked bid energy."""
         return (self._battery_energy_per_slot - self.pledged_buy_kWh[time_slot]
                 - self.offered_buy_kWh[time_slot])
@@ -574,7 +565,7 @@ class StorageState(StateInterface):
         self._battery_energy_per_slot = convert_kW_to_kWh(self.max_abs_battery_power_kW,
                                                           slot_length)
 
-    def has_battery_reached_max_power(self, energy: float, time_slot: DateTime) -> bool:
+    def _has_battery_reached_max_power(self, energy: float, time_slot: DateTime) -> bool:
         """Check whether the storage can withhold the passed energy value."""
         return limit_float_precision(abs(energy
                                      + self.pledged_sell_kWh[time_slot]
@@ -583,7 +574,7 @@ class StorageState(StateInterface):
                                      - self.offered_buy_kWh[time_slot])
                                      ) > self._battery_energy_per_slot
 
-    def clamp_energy_to_sell_kWh(self, market_slot_time_list):
+    def _clamp_energy_to_sell_kWh(self, market_slot_time_list):
         """
         Determines available energy to sell for each active market and returns a dict[TIME, FLOAT]
         """
@@ -601,13 +592,13 @@ class StorageState(StateInterface):
         for time_slot in market_slot_time_list:
             storage_dict[time_slot] = limit_float_precision(min(
                                                             energy / len(market_slot_time_list),
-                                                            self.max_offer_energy_kWh(time_slot),
+                                                            self._max_offer_energy_kWh(time_slot),
                                                             self._battery_energy_per_slot))
             self.energy_to_sell_dict[time_slot] = storage_dict[time_slot]
 
         return storage_dict
 
-    def clamp_energy_to_buy_kWh(self, market_slot_time_list):
+    def _clamp_energy_to_buy_kWh(self, market_slot_time_list):
         """
         Determines amount of energy that can be bought for each active market and writes it to
         self.energy_to_buy_dict
@@ -625,7 +616,7 @@ class StorageState(StateInterface):
 
         for time_slot in market_slot_time_list:
             clamped_energy = limit_float_precision(
-                min(energy, self.max_buy_energy_kWh(time_slot), self._battery_energy_per_slot))
+                min(energy, self._max_buy_energy_kWh(time_slot), self._battery_energy_per_slot))
             clamped_energy = max(clamped_energy, 0)
             self.energy_to_buy_dict[time_slot] = clamped_energy
 
@@ -633,6 +624,9 @@ class StorageState(StateInterface):
         """
         Sanity check of the state variables.
         """
+        self._clamp_energy_to_sell_kWh([time_slot])
+        self._clamp_energy_to_buy_kWh([time_slot])
+        self._calculate_soc_for_time_slot(time_slot)
         charge = limit_float_precision(self.used_storage / self.capacity)
         max_value = self.capacity - self.min_allowed_soc_ratio * self.capacity
         assert self.min_allowed_soc_ratio <= charge or \
@@ -646,7 +640,7 @@ class StorageState(StateInterface):
         assert 0 <= limit_float_precision(self.pledged_buy_kWh[time_slot]) <= max_value
         assert 0 <= limit_float_precision(self.offered_buy_kWh[time_slot]) <= max_value
 
-    def calculate_soc_for_time_slot(self, time_slot: DateTime) -> None:
+    def _calculate_soc_for_time_slot(self, time_slot: DateTime) -> None:
         """Update the soc history for the passed time_slot."""
         self.charge_history[time_slot] = 100.0 * self.used_storage / self.capacity
         self.charge_history_kWh[time_slot] = self.used_storage
@@ -689,7 +683,10 @@ class StorageState(StateInterface):
             self._used_storage -= self.pledged_sell_kWh[past_time_slot]
             self._used_storage += self.pledged_buy_kWh[past_time_slot]
 
-        self.calculate_soc_for_time_slot(current_time_slot)
+        self._clamp_energy_to_sell_kWh([current_time_slot, *all_future_time_slots])
+        self._clamp_energy_to_buy_kWh([current_time_slot, *all_future_time_slots])
+        self._calculate_soc_for_time_slot(current_time_slot)
+
         self.offered_history[current_time_slot] = self.offered_sell_kWh[current_time_slot]
 
         if past_time_slot:
@@ -697,6 +694,10 @@ class StorageState(StateInterface):
                 self.time_series_ess_share[past_time_slot][energy_type.origin] += energy_type.value
 
     def delete_past_state_values(self, current_time_slot: DateTime):
+        """
+        Clean up values from past market slots that are not used anymore. Useful for
+        deallocating memory that is not used anymore.
+        """
         to_delete = []
         for market_slot in self.pledged_sell_kWh:
             if is_time_slot_in_past_markets(market_slot, current_time_slot):
@@ -712,6 +713,110 @@ class StorageState(StateInterface):
             self.used_history.pop(market_slot, None)
             self.energy_to_buy_dict.pop(market_slot, None)
             self.energy_to_sell_dict.pop(market_slot, None)
+
+    def register_energy_from_posted_bid(self, energy: float, time_slot: DateTime):
+        """Register the energy from a posted bid on the market."""
+        self.offered_buy_kWh[time_slot] += energy
+
+    def register_energy_from_posted_offer(self, energy: float, time_slot: DateTime):
+        """Register the energy from a posted offer on the market."""
+        self.offered_sell_kWh[time_slot] += energy
+
+    def reset_offered_sell_energy(self, energy: float, time_slot: DateTime):
+        """Reset the offered sell energy amount."""
+        self.offered_sell_kWh[time_slot] = energy
+        self._clamp_energy_to_sell_kWh([time_slot])
+
+    def reset_offered_buy_energy(self, energy: float, time_slot: DateTime):
+        """Reset the offered buy energy amount."""
+        self.offered_buy_kWh[time_slot] = energy
+        self._clamp_energy_to_buy_kWh([time_slot])
+
+    def remove_energy_from_deleted_offer(self, energy: float, time_slot: DateTime):
+        """
+        Unregister the energy from a deleted offer, in order to be available for following offers.
+        """
+        self.offered_sell_kWh[time_slot] -= energy
+
+    def register_energy_from_one_sided_market_accept_offer(
+            self, energy: float, time_slot: DateTime,
+            energy_origin: ESSEnergyOrigin = ESSEnergyOrigin.UNKNOWN):
+        """
+        Register energy from one sided market accept offer operation. Similar behavior as
+        register_energy_from_bid_trade with the exception that offered_buy_kWh is not used in
+        one-sided markets (because there is no concept of bid, the storage never actually offers
+        energy, the buyers with access to the market can accept it).
+        """
+        self.pledged_buy_kWh[time_slot] += energy
+        self._track_energy_bought_type(energy, energy_origin)
+
+    def register_energy_from_bid_trade(
+            self, energy: float, time_slot: DateTime,
+            energy_origin: ESSEnergyOrigin = ESSEnergyOrigin.UNKNOWN):
+        """Register energy from a bid trade event."""
+        self.pledged_buy_kWh[time_slot] += energy
+        self.offered_buy_kWh[time_slot] -= energy
+        self._track_energy_bought_type(energy, energy_origin)
+
+    def register_energy_from_offer_trade(self, energy: float, time_slot: DateTime):
+        """Register energy from an offer trade event."""
+        self.pledged_sell_kWh[time_slot] += energy
+        self.offered_sell_kWh[time_slot] -= energy
+        self._track_energy_sell_type(energy)
+
+    def _track_energy_bought_type(self, energy: float, energy_origin: ESSEnergyOrigin):
+        self._used_storage_share.append(EnergyOrigin(energy_origin, energy))
+
+    # ESS Energy being utilized based on FIRST-IN FIRST-OUT mechanism
+    def _track_energy_sell_type(self, energy: float):
+        while limit_float_precision(energy) > 0 and len(self._used_storage_share) > 0:
+            first_in_energy_with_origin = self._used_storage_share[0]
+            if energy >= first_in_energy_with_origin.value:
+                energy -= first_in_energy_with_origin.value
+                self._used_storage_share.pop(0)
+            elif energy < first_in_energy_with_origin.value:
+                residual = first_in_energy_with_origin.value - energy
+                self._used_storage_share[0] = EnergyOrigin(
+                    first_in_energy_with_origin.origin, residual)
+                energy = 0
+
+    def get_available_energy_to_buy_kWh(self, time_slot: DateTime) -> float:
+        """Retrieve the amount of energy that the storage can buy in the given time slot."""
+        if self.free_storage(time_slot) == 0:
+            return 0.0
+
+        self._clamp_energy_to_buy_kWh([time_slot])
+        energy_kWh = self.energy_to_buy_dict[time_slot]
+        if self._has_battery_reached_max_power(abs(energy_kWh), time_slot):
+            return 0.0
+        return energy_kWh
+
+    def get_available_energy_to_sell_kWh(self, time_slot: DateTime) -> float:
+        """Retrieve the amount of energy that the storage can sell in the given time slot."""
+        if self.used_storage == 0:
+            return 0.0
+        energy_sell_dict = self._clamp_energy_to_sell_kWh([time_slot])
+        energy_kWh = energy_sell_dict[time_slot]
+        if self._has_battery_reached_max_power(energy_kWh, time_slot):
+            return 0.0
+        return energy_kWh
+
+    def get_soc_level(self, time_slot: DateTime) -> float:
+        """Get the SOC level of the storage, in percentage units."""
+        if self.charge_history[time_slot] == "-":
+            return self.used_storage / self.capacity
+        return self.charge_history[time_slot] / 100.0
+
+    def to_dict(self, time_slot: DateTime) -> Dict:
+        """Get a dict with the current stats of the storage according to timeslot."""
+        return {
+            "energy_to_sell": self.energy_to_sell_dict[time_slot],
+            "energy_active_in_bids": self.offered_sell_kWh[time_slot],
+            "energy_to_buy": self.energy_to_buy_dict[time_slot],
+            "energy_active_in_offers": self.offered_buy_kWh[time_slot],
+            "free_storage": self.free_storage(time_slot),
+            "used_storage": self.used_storage,
+        }
 
 
 class UnexpectedStateException(Exception):

--- a/src/gsy_e/models/state.py
+++ b/src/gsy_e/models/state.py
@@ -646,7 +646,7 @@ class StorageState(StateInterface):
         """
         self._clamp_energy_to_sell_kWh([time_slot])
         self._clamp_energy_to_buy_kWh([time_slot])
-        self._calculate_soc_for_time_slot(time_slot)
+        self._calculate_and_update_soc(time_slot)
         charge = limit_float_precision(self.used_storage / self.capacity)
         max_value = self.capacity - self.min_allowed_soc_ratio * self.capacity
         assert self.min_allowed_soc_ratio <= charge or \
@@ -661,8 +661,8 @@ class StorageState(StateInterface):
         assert 0 <= limit_float_precision(self.pledged_buy_kWh[time_slot]) <= max_value
         assert 0 <= limit_float_precision(self.offered_buy_kWh[time_slot]) <= max_value
 
-    def _calculate_soc_for_time_slot(self, time_slot: DateTime) -> None:
-        """Update the soc history for the passed time_slot."""
+    def _calculate_and_update_soc(self, time_slot: DateTime) -> None:
+        """Calculate the soc of the storage and update the soc history."""
         self.charge_history[time_slot] = 100.0 * self.used_storage / self.capacity
         self.charge_history_kWh[time_slot] = self.used_storage
 
@@ -707,7 +707,7 @@ class StorageState(StateInterface):
 
         self._clamp_energy_to_sell_kWh([current_time_slot, *all_future_time_slots])
         self._clamp_energy_to_buy_kWh([current_time_slot, *all_future_time_slots])
-        self._calculate_soc_for_time_slot(current_time_slot)
+        self._calculate_and_update_soc(current_time_slot)
 
         self.offered_history[current_time_slot] = self.offered_sell_kWh[current_time_slot]
 

--- a/src/gsy_e/models/strategy/__init__.py
+++ b/src/gsy_e/models/strategy/__init__.py
@@ -790,7 +790,8 @@ class BidEnabledStrategy(BaseStrategy):
 
             self.remove_bid_from_pending(market.id, bid.id)
             self.post_bid(market, bid.energy * updated_rate,
-                          bid.energy, attributes=bid.attributes, requirements=bid.requirements,
+                          bid.energy, replace_existing=False, attributes=bid.attributes,
+                          requirements=bid.requirements,
                           time_slot=bid.time_slot)
 
     # pylint: disable=too-many-arguments

--- a/src/gsy_e/models/strategy/future/strategy.py
+++ b/src/gsy_e/models/strategy/future/strategy.py
@@ -187,12 +187,15 @@ class FutureMarketStrategy(FutureMarketStrategyInterface):
                 available_energy_kWh = strategy.state.get_available_energy_kWh(time_slot)
                 self._post_producer_first_offer(strategy, time_slot, available_energy_kWh)
             elif strategy.asset_type == AssetType.PROSUMER:
-                available_energy_sell_kWh = strategy.get_available_energy_to_sell_kWh(time_slot)
-                available_energy_buy_kWh = strategy.get_available_energy_to_buy_kWh(time_slot)
+                available_energy_sell_kWh = strategy.state.get_available_energy_to_sell_kWh(
+                    time_slot)
+                available_energy_buy_kWh = strategy.state.get_available_energy_to_buy_kWh(
+                    time_slot)
                 self._post_producer_first_offer(strategy, time_slot, available_energy_sell_kWh)
                 self._post_consumer_first_bid(strategy, time_slot, available_energy_buy_kWh)
-                strategy.state.offered_sell_kWh[time_slot] += available_energy_sell_kWh
-                strategy.state.offered_buy_kWh[time_slot] += available_energy_buy_kWh
+                strategy.state.register_energy_from_posted_bid(available_energy_buy_kWh, time_slot)
+                strategy.state.register_energy_from_posted_offer(
+                    available_energy_sell_kWh, time_slot)
             else:
                 assert False, ("Strategy %s has to be producer or consumer to be able to "
                                "participate in the future market.", strategy.owner.name)

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -417,7 +417,6 @@ class LoadHoursStrategy(BidEnabledStrategy):
 
         if not self.area.is_market_spot_or_future(market_id):
             return
-
         if bid_trade.offer_bid.buyer == self.owner.name:
             self.state.decrement_energy_requirement(
                 bid_trade.offer_bid.energy * 1000,

--- a/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from collections import namedtuple
-from typing import Dict, Set, Optional  # noqa
+from typing import Dict, Optional  # noqa
 
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.data_classes import Offer
@@ -219,11 +219,9 @@ class MAEngine:
             # was deleted - also delete in target market
             try:
                 self.owner.delete_offer(self.markets.target, offer_info.target_offer)
-                self._delete_forwarded_offer_entries(offer_info.source_offer)
             except MarketException:
                 self.owner.log.exception("Error deleting MarketAgent offer")
-        # TODO: Should potentially handle the flip side, by not deleting the source market offer
-        # but by deleting the offered_offers entries
+        self._delete_forwarded_offer_entries(offer_info.source_offer)
 
     def event_offer_split(self, *, market_id, original_offer, accepted_offer, residual_offer):
         """Perform actions that need to be done when OFFER_SPLIT event is triggered."""

--- a/src/gsy_e/models/strategy/storage.py
+++ b/src/gsy_e/models/strategy/storage.py
@@ -24,22 +24,19 @@ from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.enums import SpotMarketTypeEnum
 from gsy_framework.read_user_profile import InputProfileTypes, read_arbitrary_profile
 from gsy_framework.utils import (
-    area_name_from_area_or_ma_name, find_object_of_same_weekday_and_time, key_in_dict_and_not_none,
-    limit_float_precision)
+    find_object_of_same_weekday_and_time, key_in_dict_and_not_none)
 from gsy_framework.validators import StorageValidator
 from pendulum import duration
 
 from gsy_e import constants
-from gsy_e.constants import FLOATING_POINT_TOLERANCE
 from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.gsy_e_core.exceptions import MarketException
 from gsy_e.models.base import AssetType
-from gsy_e.models.state import EnergyOrigin, ESSEnergyOrigin, StorageState
+from gsy_e.models.state import ESSEnergyOrigin, StorageState
 from gsy_e.models.strategy import BidEnabledStrategy
 from gsy_e.models.strategy.future.strategy import future_market_strategy_factory
 from gsy_e.models.strategy.update_frequency import (
     TemplateStrategyBidUpdater, TemplateStrategyOfferUpdater)
-
 
 log = getLogger(__name__)
 
@@ -241,7 +238,7 @@ class StorageStrategy(BidEnabledStrategy):
                 energy_rate_decrease_per_update=offer_rate_change)
 
     def event_on_disabled_area(self):
-        self.state.calculate_soc_for_time_slot(self.area.spot_market.time_slot)
+        self.state.check_state(self.area.spot_market.time_slot)
 
     def event_activate_price(self):
         """Validate rates of offers and bids when the ACTIVATE event is triggered."""
@@ -348,7 +345,6 @@ class StorageStrategy(BidEnabledStrategy):
 
         This method is triggered by the TICK event.
         """
-        self.state.clamp_energy_to_buy_kWh([self.spot_market_time_slot])
 
         market = self.area.spot_market
         self._buy_energy_two_sided_spot_market()
@@ -374,42 +370,15 @@ class StorageStrategy(BidEnabledStrategy):
         self.assert_if_trade_bid_price_is_too_high(market, trade)
         self._assert_if_trade_offer_price_is_too_low(market_id, trade)
 
-        if trade.buyer == self.owner.name:
-            if ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.ONE_SIDED.value:
-                # in order to omit double counting this is only applied for one sided market
-                self._track_energy_bought_type(trade)
         if trade.seller == self.owner.name:
-            self._track_energy_sell_type(trade)
-            self.state.pledged_sell_kWh[trade.time_slot] += trade.offer_bid.energy
-            self.state.offered_sell_kWh[trade.time_slot] -= trade.offer_bid.energy
+            self.state.register_energy_from_offer_trade(trade.offer_bid.energy, trade.time_slot)
 
-    def _is_local(self, trade):
-        for child in self.area.children:
-            if child.name == trade.seller:
-                return True
-        return False
-
-    # ESS Energy being utilized based on FIRST-IN FIRST-OUT mechanism
-    def _track_energy_sell_type(self, trade):
-        energy = trade.offer_bid.energy
-        while limit_float_precision(energy) > 0 and len(self.state.get_used_storage_share) > 0:
-            first_in_energy_with_origin = self.state.get_used_storage_share[0]
-            if energy >= first_in_energy_with_origin.value:
-                energy -= first_in_energy_with_origin.value
-                self.state.get_used_storage_share.pop(0)
-            elif energy < first_in_energy_with_origin.value:
-                residual = first_in_energy_with_origin.value - energy
-                self.state._used_storage_share[0] = EnergyOrigin(
-                    first_in_energy_with_origin.origin, residual)
-                energy = 0
-
-    def _track_energy_bought_type(self, trade):
-        if area_name_from_area_or_ma_name(trade.seller) == self.area.name:
-            self.state.update_used_storage_share(trade.offer_bid.energy, ESSEnergyOrigin.EXTERNAL)
-        elif self._is_local(trade):
-            self.state.update_used_storage_share(trade.offer_bid.energy, ESSEnergyOrigin.LOCAL)
-        else:
-            self.state.update_used_storage_share(trade.offer_bid.energy, ESSEnergyOrigin.UNKNOWN)
+    def _track_bought_energy_origin(self, seller):
+        if seller == self.area.name:
+            return ESSEnergyOrigin.EXTERNAL
+        if self.area.children and seller in [child.name for child in self.area.children]:
+            return ESSEnergyOrigin.LOCAL
+        return ESSEnergyOrigin.UNKNOWN
 
     def event_bid_traded(self, *, market_id, bid_trade):
         super().event_bid_traded(market_id=market_id, bid_trade=bid_trade)
@@ -418,9 +387,9 @@ class StorageStrategy(BidEnabledStrategy):
             return
 
         if bid_trade.buyer == self.owner.name:
-            self._track_energy_bought_type(bid_trade)
-            self.state.pledged_buy_kWh[bid_trade.time_slot] += bid_trade.offer_bid.energy
-            self.state.offered_buy_kWh[bid_trade.time_slot] -= bid_trade.offer_bid.energy
+            self.state.register_energy_from_bid_trade(
+                bid_trade.offer_bid.energy, bid_trade.time_slot,
+                self._track_bought_energy_origin(bid_trade.seller))
 
     def _cycle_state(self):
         current_market = self.area.spot_market
@@ -484,10 +453,11 @@ class StorageStrategy(BidEnabledStrategy):
             return None
 
         try:
-            self.state.clamp_energy_to_buy_kWh([market.time_slot])
-            max_energy = min(offer.energy, self.state.energy_to_buy_dict[market.time_slot])
-            if not self.state.has_battery_reached_max_power(-max_energy, market.time_slot):
-                self.state.pledged_buy_kWh[market.time_slot] += max_energy
+            max_energy = self.state.get_available_energy_to_buy_kWh(market.time_slot)
+            max_energy = min(offer.energy, max_energy)
+            if max_energy > 0.0:
+                self.state.register_energy_from_one_sided_market_accept_offer(
+                    max_energy, market.time_slot, self._track_bought_energy_origin(offer.seller))
                 self.accept_offer(market, offer, energy=max_energy,
                                   buyer_origin=self.owner.name,
                                   buyer_origin_id=self.owner.uuid,
@@ -500,12 +470,7 @@ class StorageStrategy(BidEnabledStrategy):
     def _buy_energy_one_sided_spot_market(self, market, offer=None):
         if not market:
             return
-        if self.state.has_battery_reached_max_power(-FLOATING_POINT_TOLERANCE, market.time_slot):
-            return
         max_affordable_offer_rate = self.bid_update.get_updated_rate(market.time_slot)
-        # Check if storage has free capacity
-        if self.state.free_storage(market.time_slot) <= 0.0:
-            return
 
         if offer:
             self._try_to_buy_offer(offer, market, max_affordable_offer_rate)
@@ -516,30 +481,14 @@ class StorageStrategy(BidEnabledStrategy):
                     return
 
     def _sell_energy_to_spot_market(self):
-        if self.state.used_storage == 0:
-            return
-
         time_slot = self.area.spot_market.time_slot
         selling_rate = self.calculate_selling_rate(self.area.spot_market)
-        energy_kWh = self.get_available_energy_to_sell_kWh(time_slot)
+        energy_kWh = self.state.get_available_energy_to_sell_kWh(time_slot)
         if energy_kWh > 0.0:
             offer = self.post_first_offer(
                 self.area.spot_market, energy_kWh, selling_rate
             )
-            self.state.offered_sell_kWh[time_slot] += offer.energy
-
-    def get_available_energy_to_sell_kWh(self, time_slot):
-        """Retrieve the amount of energy that the storage can sell in the given time slot."""
-        energy_sell_dict = self.state.clamp_energy_to_sell_kWh([time_slot])
-        energy_kWh = energy_sell_dict[time_slot]
-        if self.state.has_battery_reached_max_power(energy_kWh, time_slot):
-            return 0.0
-        return energy_kWh
-
-    def get_available_energy_to_buy_kWh(self, time_slot):
-        """Retrieve the amount of energy that the storage can buy in the given time slot."""
-        self.state.clamp_energy_to_buy_kWh([time_slot])
-        return self.state.energy_to_buy_dict[time_slot]
+            self.state.register_energy_from_posted_offer(offer.energy, time_slot)
 
     def _buy_energy_two_sided_spot_market(self):
         if ConstSettings.MASettings.MARKET_TYPE != SpotMarketTypeEnum.TWO_SIDED.value:
@@ -552,13 +501,13 @@ class StorageStrategy(BidEnabledStrategy):
 
         self.bid_update.reset(self)
 
-        energy_kWh = self.get_available_energy_to_buy_kWh(time_slot)
+        energy_kWh = self.state.get_available_energy_to_buy_kWh(time_slot)
         energy_rate = self.bid_update.initial_rate[time_slot]
         if energy_kWh > 0:
             try:
                 first_bid = self.post_first_bid(market, energy_kWh * 1000.0, energy_rate)
                 if first_bid is not None:
-                    self.state.offered_buy_kWh[time_slot] += first_bid.energy
+                    self.state.register_energy_from_posted_bid(first_bid.energy, time_slot)
             except MarketException:
                 pass
 
@@ -570,10 +519,7 @@ class StorageStrategy(BidEnabledStrategy):
         return self.offer_update.initial_rate[market.time_slot]
 
     def _capacity_dependant_sell_rate(self, market):
-        if self.state.charge_history[market.time_slot] == "-":
-            soc = self.state.used_storage / self.state.capacity
-        else:
-            soc = self.state.charge_history[market.time_slot] / 100.0
+        soc = self.state.get_soc_level(market.time_slot)
         max_selling_rate = self.offer_update.initial_rate[market.time_slot]
         min_selling_rate = self.offer_update.final_rate[market.time_slot]
         if max_selling_rate < min_selling_rate:

--- a/src/gsy_e/models/strategy/storage.py
+++ b/src/gsy_e/models/strategy/storage.py
@@ -22,6 +22,7 @@ from typing import Union
 
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.enums import SpotMarketTypeEnum
+from gsy_framework.exceptions import GSyException
 from gsy_framework.read_user_profile import InputProfileTypes, read_arbitrary_profile
 from gsy_framework.utils import (
     find_object_of_same_weekday_and_time, key_in_dict_and_not_none)
@@ -185,7 +186,7 @@ class StorageStrategy(BidEnabledStrategy):
                                  initial_buying_rate, final_buying_rate,
                                  energy_rate_increase_per_update, energy_rate_decrease_per_update,
                                  bid_fit_to_limit, offer_fit_to_limit)
-        except Exception as ex:
+        except GSyException as ex:
             log.exception("StorageStrategy._area_reconfigure_prices failed. Exception: %s.", ex)
             return
 
@@ -252,7 +253,10 @@ class StorageStrategy(BidEnabledStrategy):
 
     def event_activate_energy(self):
         """Set the battery energy for each slot when the ACTIVATE event is triggered."""
-        self.state.set_battery_energy_per_slot(self.simulation_config.slot_length)
+        self.state.activate(
+            self.simulation_config.slot_length,
+            self.area.current_market.time_slot
+            if self.area.current_market else self.area.config.start_date)
 
     def event_activate(self, **kwargs):
         self._update_profiles_with_default_values()

--- a/src/gsy_e/setup/jira/d3asim_780.py
+++ b/src/gsy_e/setup/jira/d3asim_780.py
@@ -34,7 +34,7 @@ def get_setup(config):
                 [
                     Area("H1 Electrolyser",
                          strategy=ElectrolyzerStrategy(discharge_profile=discharge_path,
-                                                       production_rate_kg_h=4.0)
+                                                       production_rate_kg_h=10.0)
                          ),
                 ]
             ),

--- a/src/gsy_e/setup/kpi/d3asim_2103.py
+++ b/src/gsy_e/setup/kpi/d3asim_2103.py
@@ -14,8 +14,7 @@ def get_setup(config):
 
     ConstSettings.GeneralSettings.DEFAULT_UPDATE_INTERVAL = 1
     ConstSettings.MASettings.MARKET_TYPE = 1
-    ConstSettings.MASettings.MIN_OFFER_AGE = 0
-    ConstSettings.MASettings.MIN_BID_AGE = 0
+    ConstSettings.MASettings.MIN_OFFER_AGE = 1
 
     area = Area(
         "Grid",

--- a/tests/strategies/future/test_future_strategy.py
+++ b/tests/strategies/future/test_future_strategy.py
@@ -99,6 +99,7 @@ class TestFutureMarketStrategy:
         storage_strategy_fixture = StorageStrategy()
         future_strategy = FutureMarketStrategy(storage_strategy_fixture.asset_type, 10, 50, 50, 20)
         self._setup_strategy_fixture(storage_strategy_fixture)
+        storage_strategy_fixture.state.activate(duration(minutes=15), self.time_slot)
         storage_strategy_fixture.state.offered_sell_kWh[self.time_slot] = 0.
         storage_strategy_fixture.state.offered_buy_kWh[self.time_slot] = 0.
         storage_strategy_fixture.state.pledged_sell_kWh[self.time_slot] = 0.
@@ -135,6 +136,7 @@ class TestFutureMarketStrategy:
         if isinstance(future_strategy_fixture, PVStrategy):
             future_strategy_fixture.state.set_available_energy(300.0, self.time_slot)
         if isinstance(future_strategy_fixture, StorageStrategy):
+            future_strategy_fixture.state.activate(duration(minutes=15), self.time_slot)
             future_strategy_fixture.get_available_energy_to_buy_kWh = Mock(return_value=3)
             future_strategy_fixture.get_available_energy_to_sell_kWh = Mock(return_value=2)
             future_strategy_fixture.state.offered_sell_kWh[self.time_slot] = 0.

--- a/tests/strategies/future/test_future_strategy.py
+++ b/tests/strategies/future/test_future_strategy.py
@@ -101,8 +101,10 @@ class TestFutureMarketStrategy:
         self._setup_strategy_fixture(storage_strategy_fixture)
         storage_strategy_fixture.state.offered_sell_kWh[self.time_slot] = 0.
         storage_strategy_fixture.state.offered_buy_kWh[self.time_slot] = 0.
-        storage_strategy_fixture.get_available_energy_to_buy_kWh = Mock(return_value=3)
-        storage_strategy_fixture.get_available_energy_to_sell_kWh = Mock(return_value=2)
+        storage_strategy_fixture.state.pledged_sell_kWh[self.time_slot] = 0.
+        storage_strategy_fixture.state.pledged_buy_kWh[self.time_slot] = 0.
+        storage_strategy_fixture.state.get_available_energy_to_buy_kWh = Mock(return_value=3)
+        storage_strategy_fixture.state.get_available_energy_to_sell_kWh = Mock(return_value=2)
         future_strategy.event_market_cycle(storage_strategy_fixture)
         self.future_markets.offer.assert_called_once_with(
             price=50.0 * 2, energy=2, seller=self.area_mock.name,
@@ -137,6 +139,8 @@ class TestFutureMarketStrategy:
             future_strategy_fixture.get_available_energy_to_sell_kWh = Mock(return_value=2)
             future_strategy_fixture.state.offered_sell_kWh[self.time_slot] = 0.
             future_strategy_fixture.state.offered_buy_kWh[self.time_slot] = 0.
+            future_strategy_fixture.state.pledged_sell_kWh[self.time_slot] = 0.
+            future_strategy_fixture.state.pledged_buy_kWh[self.time_slot] = 0.
 
         future_strategy_fixture.area.current_tick = 0
         future_strategy.event_market_cycle(future_strategy_fixture)

--- a/tests/strategies/test_strategy_storage.py
+++ b/tests/strategies/test_strategy_storage.py
@@ -62,6 +62,7 @@ class FakeArea:
         self.current_market = FakeMarket(0)
         self.spot_market = self.current_market
         self.test_balancing_market = FakeMarket(1)
+        self.children = []
 
     log = getLogger(__name__)
 
@@ -423,7 +424,7 @@ def test_sell_energy_function(storage_strategy_test7, area_test7: FakeArea):
     storage_strategy_test7.event_activate()
     sell_market = area_test7.spot_market
     energy_sell_dict = \
-        storage_strategy_test7.state.clamp_energy_to_sell_kWh([sell_market.time_slot])
+        storage_strategy_test7.state._clamp_energy_to_sell_kWh([sell_market.time_slot])
     storage_strategy_test7.event_market_cycle()
     assert(isclose(storage_strategy_test7.state.offered_sell_kWh[sell_market.time_slot],
                    energy_sell_dict[sell_market.time_slot], rel_tol=1e-03))
@@ -475,7 +476,7 @@ def test_calculate_energy_amount_to_sell_respects_min_allowed_soc(storage_strate
                                                                   area_test7):
     storage_strategy_test7_3.event_activate()
     time_slot = area_test7.current_market.time_slot
-    energy_sell_dict = storage_strategy_test7_3.state.clamp_energy_to_sell_kWh(
+    energy_sell_dict = storage_strategy_test7_3.state._clamp_energy_to_sell_kWh(
         [time_slot])
     target_energy = (storage_strategy_test7_3.state.used_storage
                      - storage_strategy_test7_3.state.pledged_sell_kWh[time_slot]
@@ -490,7 +491,7 @@ def test_clamp_energy_to_buy(storage_strategy_test7_3):
     storage_strategy_test7_3.event_activate()
     storage_strategy_test7_3.state._battery_energy_per_slot = 0.5
     time_slot = storage_strategy_test7_3.market.time_slot
-    storage_strategy_test7_3.state.clamp_energy_to_buy_kWh([time_slot])
+    storage_strategy_test7_3.state._clamp_energy_to_buy_kWh([time_slot])
     assert storage_strategy_test7_3.state.energy_to_buy_dict[time_slot] == \
         storage_strategy_test7_3.state._battery_energy_per_slot
 
@@ -498,7 +499,7 @@ def test_clamp_energy_to_buy(storage_strategy_test7_3):
 
     storage_strategy_test7_3.state._used_storage = 4.6
     assert isclose(storage_strategy_test7_3.state.free_storage(time_slot), 0.41)
-    storage_strategy_test7_3.state.clamp_energy_to_buy_kWh([time_slot])
+    storage_strategy_test7_3.state._clamp_energy_to_buy_kWh([time_slot])
     assert isclose(storage_strategy_test7_3.state.energy_to_buy_dict[time_slot], 0.41)
 
 
@@ -654,8 +655,8 @@ def test_has_battery_reached_max_power(storage_strategy_test11):
     storage_strategy_test11.state.offered_sell_kWh[time_slot] = 5
     storage_strategy_test11.state.pledged_buy_kWh[time_slot] = 5
     storage_strategy_test11.state.offered_buy_kWh[time_slot] = 5
-    assert storage_strategy_test11.state.has_battery_reached_max_power(1, time_slot) is True
-    assert storage_strategy_test11.state.has_battery_reached_max_power(0.25, time_slot) is False
+    assert storage_strategy_test11.state._has_battery_reached_max_power(1, time_slot) is True
+    assert storage_strategy_test11.state._has_battery_reached_max_power(0.25, time_slot) is False
 
 
 """TEST12"""
@@ -833,37 +834,44 @@ def storage_strategy_test15(area_test15, called):
 
 def test_energy_origin(storage_strategy_test15, market_test15):
     storage_strategy_test15.event_activate()
-    assert len(storage_strategy_test15.state.get_used_storage_share) == 1
-    assert storage_strategy_test15.state.get_used_storage_share[0] == EnergyOrigin(
+    assert len(storage_strategy_test15.state._used_storage_share) == 1
+    assert storage_strategy_test15.state._used_storage_share[0] == EnergyOrigin(
         ESSEnergyOrigin.EXTERNAL, 15)
-    storage_strategy_test15.area.current_market.trade = \
-        Trade('id', 'time', Offer('id', now(), 20, 1.0, 'OtherChildArea'),
-              'OtherChildArea', 'Storage')
-    storage_strategy_test15.event_offer_traded(
-        market_id=market_test15.id,
-        trade=storage_strategy_test15.area.current_market.trade)
-    assert len(storage_strategy_test15.state.get_used_storage_share) == 2
-    assert storage_strategy_test15.state.get_used_storage_share == [EnergyOrigin(
+
+    # Validate that local energy origin is correctly registered
+    current_market = storage_strategy_test15.area.current_market
+    offer = Offer('id', now(), 20, 1.0, 'OtherChildArea')
+    storage_strategy_test15._try_to_buy_offer(offer, current_market, 21)
+    storage_strategy_test15.area.current_market.trade = Trade(
+        'id', now(), offer, 'OtherChildArea', 'Storage')
+    storage_strategy_test15.event_offer_traded(market_id=market_test15.id,
+                                               trade=current_market.trade)
+    assert len(storage_strategy_test15.state._used_storage_share) == 2
+    assert storage_strategy_test15.state._used_storage_share == [EnergyOrigin(
         ESSEnergyOrigin.EXTERNAL, 15), EnergyOrigin(ESSEnergyOrigin.LOCAL, 1)]
 
-    storage_strategy_test15.area.current_market.trade = \
-        Trade('id', 'time', Offer('id', now(), 20, 2.0, 'Storage'),
-              'Storage', 'A', time_slot=storage_strategy_test15.area.current_market.time_slot)
+    # Validate that local energy origin with the same seller / buyer is correctly registered
+    offer = Offer('id', now(), 20, 2.0, 'Storage')
+    storage_strategy_test15._try_to_buy_offer(offer, current_market, 21)
+    storage_strategy_test15.area.current_market.trade = Trade(
+        'id', now(), offer, 'Storage', 'A',
+        time_slot=current_market.time_slot)
     storage_strategy_test15.event_offer_traded(
         market_id=market_test15.id,
-        trade=storage_strategy_test15.area.current_market.trade)
-    assert len(storage_strategy_test15.state.get_used_storage_share) == 2
-    assert storage_strategy_test15.state.get_used_storage_share == [EnergyOrigin(
+        trade=current_market.trade)
+    assert len(storage_strategy_test15.state._used_storage_share) == 2
+    assert storage_strategy_test15.state._used_storage_share == [EnergyOrigin(
         ESSEnergyOrigin.EXTERNAL, 13), EnergyOrigin(ESSEnergyOrigin.LOCAL, 1)]
 
-    storage_strategy_test15.area.current_market.trade = \
-        Trade('id', 'time', Offer('id', now(), 20, 1.0, 'FakeArea'),
-              'FakeArea', 'Storage')
+    # Validate that external energy origin is correctly registered
+    offer = Offer('id', now(), 20, 1.0, 'FakeArea')
+    storage_strategy_test15._try_to_buy_offer(offer, current_market, 21)
+    current_market.trade = Trade('id', now(), offer, 'FakeArea', 'Storage')
     storage_strategy_test15.event_offer_traded(
         market_id=market_test15.id,
-        trade=storage_strategy_test15.area.current_market.trade)
-    assert len(storage_strategy_test15.state.get_used_storage_share) == 3
-    assert storage_strategy_test15.state.get_used_storage_share == [EnergyOrigin(
+        trade=current_market.trade)
+    assert len(storage_strategy_test15.state._used_storage_share) == 3
+    assert storage_strategy_test15.state._used_storage_share == [EnergyOrigin(
         ESSEnergyOrigin.EXTERNAL, 13.0), EnergyOrigin(ESSEnergyOrigin.LOCAL, 1.0),
         EnergyOrigin(ESSEnergyOrigin.EXTERNAL, 1.0)]
 

--- a/tests/strategies/test_strategy_storage.py
+++ b/tests/strategies/test_strategy_storage.py
@@ -655,8 +655,10 @@ def test_has_battery_reached_max_power(storage_strategy_test11):
     storage_strategy_test11.state.offered_sell_kWh[time_slot] = 5
     storage_strategy_test11.state.pledged_buy_kWh[time_slot] = 5
     storage_strategy_test11.state.offered_buy_kWh[time_slot] = 5
-    assert storage_strategy_test11.state._has_battery_reached_max_power(1, time_slot) is True
-    assert storage_strategy_test11.state._has_battery_reached_max_power(0.25, time_slot) is False
+    assert storage_strategy_test11.state._has_battery_reached_max_discharge_power(
+        1, time_slot) is True
+    assert storage_strategy_test11.state._has_battery_reached_max_discharge_power(
+        0.25, time_slot) is False
 
 
 """TEST12"""

--- a/tests/strategies/test_strategy_storage.py
+++ b/tests/strategies/test_strategy_storage.py
@@ -386,6 +386,7 @@ def storage_strategy_test6(area_test6, market_test6, called):
     s.area = area_test6
     s.accept_offer = called
     s.offers.post(market_test6.trade.offer_bid, market_test6.id)
+    s.event_activate()
     return s
 
 
@@ -630,6 +631,7 @@ def storage_strategy_test11(area_test11, called):
     s.owner = area_test11
     s.area = area_test11
     s.accept_offer = called
+    s.event_activate()
     return s
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,8 @@ passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH SOLC_BINARY BRANCH
 deps =
 	pip-tools
 	coverage
+whitelist_externals = coverage
+
 commands =
 	python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
     pip-sync requirements/tests.txt requirements/pandapower.txt
@@ -82,7 +84,7 @@ commands =
     coverage combine
     coverage xml
     coverage report
-    behave --tags=-slow --tags=-disabled integration_tests
+    bash -c 'for f in ./integration_tests/*.feature; do behave --tags=-slow --tags=-disabled "$f"; done'
 
 [testenv:test_dispatch_events_top_to_bottom]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH SOLC_BINARY BRANCH
 deps =
 	pip-tools
 	coverage
-whitelist_externals = coverage
+whitelist_externals = bash
 
 commands =
 	python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
@@ -84,7 +84,7 @@ commands =
     coverage combine
     coverage xml
     coverage report
-    bash -c 'for f in ./integration_tests/*.feature; do behave --tags=-slow --tags=-disabled "$f"; done'
+    bash -c 'for f in ./integration_tests/*.feature; do behave --tags=-slow --tags=-disabled "$f" || exit 1; done'
 
 [testenv:test_dispatch_events_top_to_bottom]
 basepython = python3.8


### PR DESCRIPTION
Contains various different fixes to correct the behavior of the agents and the storage strategy with regards to future markets. The main fixes are in the following areas:
- Bug fixes in the area dispatcher and agent engine classes, that were the root cause of the main issue (offer / bid delete raised exception during cleanup), because the delete event was not forwarded to all future market areas correctly when the delete offer / bid originated from an area other than Home markets. 
- Refactoring of the StorageStrategy / StorageState classes in order to minimize the number of interactions across the 2, and to not use internal properties of the StorageState e.g. offered_sell_kWh. New methods were created in order to get the available energy for buy and sell, and also for updating the properties of the state on offer / bid , delete and trade. Also made private some methods of the StorageState class (e.g. clamp_energy_to_buy/sell which can be triggered internally in the class and does not need to be exposed)
- One specific future market-related fix on the StorageState, which was to take into account the future offered / traded energy when calculating the available energy for spot and future market slots. 
- Adapted tox configuration in order to be able to run each feature file in its own behave process (contrary to running all feature files in the same behave process as it was done till now). The intent is to decrease the total runtime of the integration tests, since it was observed that on the local machine, the integration tests were executed much faster this way. 

It is more convenient to review each commit separately. 