### PR TITLE
Bug/gsye 150 Send external events and responses via redis queue

### DIFF
--- a/src/gsy_e/constants.py
+++ b/src/gsy_e/constants.py
@@ -60,6 +60,7 @@ CN_PROFILE_EXPANSION_DAYS = 7
 RUN_IN_REALTIME = False
 
 CONNECT_TO_PROFILES_DB = False
+SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ = False
 
 
 class SettlementTemplateStrategiesConstants:

--- a/src/gsy_e/gsy_e_core/cli.py
+++ b/src/gsy_e/gsy_e_core/cli.py
@@ -133,8 +133,6 @@ def run(setup_module_name, settings_file, duration, slot_length, tick_length,
                 external_connection_enabled=enable_external_connection,
                 enable_degrees_of_freedom=enable_dof)
 
-        gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ = False
-
         if compare_alt_pricing is True:
             ConstSettings.MASettings.AlternativePricing.COMPARE_PRICING_SCHEMES = True
             # we need the seconds in the export dir name

--- a/src/gsy_e/gsy_e_core/cli.py
+++ b/src/gsy_e/gsy_e_core/cli.py
@@ -24,13 +24,12 @@ import click
 from click.types import Choice
 from click_default_group import DefaultGroup
 from colorlog.colorlog import ColoredFormatter
-from pendulum import DateTime, today
-
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.exceptions import GSyException
 from gsy_framework.settings_validators import validate_global_settings
+from pendulum import DateTime, today
 
-from gsy_e.constants import DATE_FORMAT, DATE_TIME_FORMAT, TIME_FORMAT, TIME_ZONE
+import gsy_e.constants
 from gsy_e.gsy_e_core.simulation import run_simulation
 from gsy_e.gsy_e_core.util import (
     DateType, IntervalType, available_simulation_scenarios, convert_str_to_pause_after_interval,
@@ -85,7 +84,8 @@ _setup_modules = available_simulation_scenarios
               help="Start simulation in paused state")
 @click.option("--pause-at", type=str, default=None,
               help="Automatically pause at a certain time. "
-              f"Accepted Input formats: ({DATE_FORMAT}, {TIME_FORMAT}) [default: disabled]")
+              f"Accepted Input formats: ({gsy_e.constants.DATE_FORMAT}, "
+                   f"{gsy_e.constants.TIME_FORMAT}) [default: disabled]")
 @click.option("--repl/--no-repl", default=False, show_default=True,
               help="Start REPL after simulation run.")
 @click.option("--no-export", is_flag=True, default=False, help="Skip export of simulation data")
@@ -96,9 +96,10 @@ _setup_modules = available_simulation_scenarios
               help="Compare alternative pricing schemes")
 @click.option("--enable-external-connection", is_flag=True, default=False,
               help="External Agents interaction to simulation during runtime")
-@click.option("--start-date", type=DateType(DATE_FORMAT),
-              default=today(tz=TIME_ZONE).format(DATE_FORMAT), show_default=True,
-              help=f"Start date of the Simulation ({DATE_FORMAT})")
+@click.option("--start-date", type=DateType(gsy_e.constants.DATE_FORMAT),
+              default=today(tz=gsy_e.constants.TIME_ZONE).format(gsy_e.constants.DATE_FORMAT),
+              show_default=True,
+              help=f"Start date of the Simulation ({gsy_e.constants.DATE_FORMAT})")
 @click.option("--enable-dof/--disable-dof",
               is_flag=True, default=True,
               help=(
@@ -132,10 +133,13 @@ def run(setup_module_name, settings_file, duration, slot_length, tick_length,
                 external_connection_enabled=enable_external_connection,
                 enable_degrees_of_freedom=enable_dof)
 
+        gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ = False
+
         if compare_alt_pricing is True:
             ConstSettings.MASettings.AlternativePricing.COMPARE_PRICING_SCHEMES = True
             # we need the seconds in the export dir name
-            kwargs["export_subdir"] = DateTime.now(tz=TIME_ZONE).format(f"{DATE_TIME_FORMAT}:ss")
+            kwargs["export_subdir"] = DateTime.now(tz=gsy_e.constants.TIME_ZONE).format(
+                f"{gsy_e.constants.DATE_TIME_FORMAT}:ss")
             processes = []
             for pricing_scheme in range(0, 4):
                 kwargs["pricing_scheme"] = pricing_scheme

--- a/src/gsy_e/gsy_e_core/redis_connections/redis_area_market_communicator.py
+++ b/src/gsy_e/gsy_e_core/redis_connections/redis_area_market_communicator.py
@@ -94,7 +94,10 @@ class BlockingCommunicator(RedisCommunicator):
 
 
 class ResettableCommunicator(RedisCommunicator):
-    """Communicator for sending messages using redis pubsub including."""
+    """
+    Communicator for sending messages adn receiving their responses using redis pubsub
+    that runs in a thread which can be restarted.
+    """
 
     def __init__(self):
         super().__init__()

--- a/src/gsy_e/gsy_e_core/redis_connections/redis_area_market_communicator.py
+++ b/src/gsy_e/gsy_e_core/redis_connections/redis_area_market_communicator.py
@@ -17,59 +17,91 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import json
 import logging
-from threading import Event, Lock
+from threading import Event, Lock, Thread
 from time import time
+from typing import Dict
+from collections.abc import Callable
+
+from gsy_framework.constants_limits import ConstSettings
+from redis import StrictRedis
+from rq import Queue
 
 import gsy_e.constants
 from gsy_e.constants import REDIS_PUBLISH_RESPONSE_TIMEOUT
 from gsy_e.gsy_e_core.redis_connections.aggregator_connection import AggregatorHandler
 from gsy_e.gsy_e_core.redis_connections.redis_communication import REDIS_URL
-from redis import StrictRedis
-from rq import Queue
 
 log = logging.getLogger(__name__)
 REDIS_THREAD_JOIN_TIMEOUT = 2
 REDIS_POLL_TIMEOUT = 0.01
-SDK_COM_QUEUE_NAME = "sdk-events-responses"
-SEND_SDK_MESSAGES_VIA_RQ = True
 
 
 class RedisCommunicator:
+    """Base class for redis communication using pubsub."""
+
     def __init__(self):
         self.redis_db = StrictRedis.from_url(REDIS_URL, retry_on_timeout=True)
         self.pubsub = self.redis_db.pubsub()
         self.pubsub_response = self.redis_db.pubsub()
         self.event = Event()
 
-    def publish(self, channel, data):
+    def publish(self, channel: str, data: str):
+        """Publish message on redis channel."""
         self.redis_db.publish(channel, data)
 
     def wait(self):
+        """Wait for thread event to be performed."""
         self.event.wait()
         self.event.clear()
 
     def resume(self):
+        """Resume receiving events."""
         self.event.set()
 
-    def sub_to_response(self, channel, callback):
+    def sub_to_response(self, channel: str, callback: Callable) -> Thread:
+        """Subscribe to response channel and return pubsub thread."""
         self.pubsub_response.subscribe(**{channel: callback})
         thread = self.pubsub_response.run_in_thread(daemon=True)
         log.trace(f"Started thread for responses: {thread}")
         return thread
 
-    def sub_to_channel(self, channel, callback):
+    def sub_to_channel(self, channel: str, callback: Callable) -> Thread:
+        """Subscribe to channel and return pubsub thread."""
         self.pubsub.subscribe(**{channel: callback})
         thread = self.pubsub.run_in_thread(daemon=True)
         log.trace(f"Started thread for events: {thread}")
         return thread
 
 
+class BlockingCommunicator(RedisCommunicator):
+    """Communicator for sending blocking messages via redis pubsub."""
+
+    def __init__(self):
+        super().__init__()
+        self.lock = Lock()
+
+    def sub_to_channel(self, channel: str, callback: Callable):
+        """Subscribe to channel."""
+        self.pubsub.subscribe(**{channel: callback})
+
+    def poll_until_response_received(self, response_received_callback: Callable):
+        """Wait until response of send message was received."""
+        start_time = time()
+        while not response_received_callback() and \
+                (time() - start_time < REDIS_PUBLISH_RESPONSE_TIMEOUT):
+            with self.lock:
+                self.pubsub.get_message(timeout=REDIS_POLL_TIMEOUT)
+
+
 class ResettableCommunicator(RedisCommunicator):
+    """Communicator for sending messages using redis pubsub including."""
+
     def __init__(self):
         super().__init__()
         self.thread = None
 
     def terminate_connection(self):
+        """Terminate connection to redis pubsub."""
         try:
             self.thread.stop()
             self.thread.join(timeout=REDIS_THREAD_JOIN_TIMEOUT)
@@ -78,7 +110,7 @@ class ResettableCommunicator(RedisCommunicator):
         except Exception as e:
             logging.debug(f"Error when stopping all threads: {e}")
 
-    def sub_to_multiple_channels(self, channel_callback_dict):
+    def sub_to_multiple_channels(self, channel_callback_dict: Dict):
         assert self.thread is None, \
             f"There has to be only one thread per ResettableCommunicator object, " \
             f" thread {self.thread} already exists."
@@ -87,25 +119,28 @@ class ResettableCommunicator(RedisCommunicator):
         log.debug(f"Started ResettableCommunicator thread for multiple channels: {thread}")
         self.thread = thread
 
-    def sub_to_response(self, channel, callback):
+    def sub_to_response(self, channel: str, callback: Callable):
         assert self.thread is None, \
             f"There has to be only one thread per ResettableCommunicator object, " \
             f" thread {self.thread} already exists."
         thread = super().sub_to_response(channel, callback)
         self.thread = thread
 
-    def publish_json(self, channel, data):
-        if SEND_SDK_MESSAGES_VIA_RQ:
-            self.send_to_queue(channel, json.dumps(data))
-        else:
-            self.publish(channel, json.dumps(data))
+    def publish_json(self, channel: str, data: Dict):
+        self.publish(channel, json.dumps(data))
 
-    def send_to_queue(self, channel, data):
-        queue = Queue(SDK_COM_QUEUE_NAME, connection=self.redis_db)
-        queue.enqueue(channel, data)
+
+class RQResettableCommunicator(ResettableCommunicator):
+    """Communicator for sending messages using redis queue."""
+
+    def publish_json(self, channel: str, data: Dict) -> None:
+        queue = Queue(ConstSettings.GeneralSettings.SDK_COM_QUEUE_NAME, connection=self.redis_db)
+        queue.enqueue(channel, json.dumps(data))
 
 
 class ExternalConnectionCommunicator(ResettableCommunicator):
+    """Communicator for sending messages using redis pubsub including utils for aggregator."""
+
     def __init__(self, is_enabled):
         self.is_enabled = is_enabled
         self.aggregator = None
@@ -114,12 +149,12 @@ class ExternalConnectionCommunicator(ResettableCommunicator):
             self.channel_callback_dict = {}
             self.aggregator = AggregatorHandler(self.redis_db)
 
-    def sub_to_channel(self, channel, callback):
+    def sub_to_channel(self, channel: str, callback: Callable):
         if not self.is_enabled:
             return
         self.pubsub.subscribe(**{channel: callback})
 
-    def sub_to_multiple_channels(self, channel_callback_dict):
+    def sub_to_multiple_channels(self, channel_callback_dict: Dict):
         if not self.is_enabled:
             return
         self.pubsub.subscribe(**channel_callback_dict)
@@ -156,17 +191,18 @@ class ExternalConnectionCommunicator(ResettableCommunicator):
         self.aggregator.publish_all_events(self)
 
 
-class BlockingCommunicator(RedisCommunicator):
-    def __init__(self):
-        super().__init__()
-        self.lock = Lock()
+class RQExternalConnectionCommunicator(ExternalConnectionCommunicator, RQResettableCommunicator):
+    """Communicator for sending messages using redis queue including utils for aggregator."""
 
-    def sub_to_channel(self, channel, callback):
-        self.pubsub.subscribe(**{channel: callback})
 
-    def poll_until_response_received(self, response_received_callback):
-        start_time = time()
-        while not response_received_callback() and \
-                (time() - start_time < REDIS_PUBLISH_RESPONSE_TIMEOUT):
-            with self.lock:
-                self.pubsub.get_message(timeout=REDIS_POLL_TIMEOUT)
+def external_redis_communicator_factory(is_enabled: bool) -> ExternalConnectionCommunicator:
+    """Return either a rq or pubsub based external communicator including aggregator utils."""
+    return (RQExternalConnectionCommunicator(is_enabled)
+            if gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ
+            else ExternalConnectionCommunicator(is_enabled))
+
+
+def myco_redis_communicator_factory() -> ResettableCommunicator:
+    """Return either a rq or pubsub based external communicator."""
+    return (RQResettableCommunicator()
+            if gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ else ResettableCommunicator())

--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -88,6 +88,7 @@ def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
             duration(seconds=settings["slot_length_realtime"].seconds)
             if "slot_length_realtime" in settings else None)
 
+        gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ = True
         config = SimulationConfig(**config_settings)
 
         spot_market_type = settings.get("spot_market_type")
@@ -122,7 +123,6 @@ def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
                   "seed": settings.get("random_seed", 0)}
 
         gsy_e.constants.CONNECT_TO_PROFILES_DB = True
-        gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ = True
 
         run_simulation(setup_module_name=scenario_name,
                        simulation_config=config,

--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -115,6 +115,7 @@ def launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_
                   "seed": settings.get('random_seed', 0)}
 
         gsy_e.constants.CONNECT_TO_PROFILES_DB = True
+        gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ = True
 
         run_simulation(setup_module_name=scenario_name,
                        simulation_config=config,

--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -2,7 +2,9 @@ import ast
 import json
 import logging
 import pickle
+import traceback
 from datetime import datetime, date
+from typing import Dict, Optional
 from zlib import decompress
 
 from gsy_framework.constants_limits import GlobalConfig, ConstSettings
@@ -17,12 +19,16 @@ from gsy_e.models.config import SimulationConfig
 log = logging.getLogger()
 
 
-def decompress_and_decode_queued_strings(queued_string):
+def decompress_and_decode_queued_strings(queued_string: bytes) -> Dict:
+    """Decompress and decode data sent via redis queue."""
     return pickle.loads(decompress(queued_string))
 
 
-def launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_mapping,
-                                  saved_state, job_id):
+# pylint: disable=too-many-arguments, too-many-locals
+def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
+                                  events: Optional[str], aggregator_device_mapping: str,
+                                  saved_state: bytes, job_id: str):
+    """Launch simulation from rq job."""
     logging.getLogger().setLevel(logging.ERROR)
     scenario = decompress_and_decode_queued_strings(scenario)
     gsy_e.constants.CONFIGURATION_ID = scenario.pop("configuration_uuid")
@@ -31,7 +37,7 @@ def launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_
         GlobalConfig.IS_CANARY_NETWORK = scenario.pop("is_canary_network", False)
         gsy_e.constants.RUN_IN_REALTIME = GlobalConfig.IS_CANARY_NETWORK
     saved_state = decompress_and_decode_queued_strings(saved_state)
-    log.error(f"Starting simulation with job_id: {job_id}")
+    log.error("Starting simulation with job_id: %s", job_id)
 
     try:
         if settings is None:
@@ -39,7 +45,7 @@ def launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_
         else:
             settings = {k: v for k, v in settings.items() if v is not None and v != "None"}
 
-        advanced_settings = settings.get('advanced_settings', None)
+        advanced_settings = settings.get("advanced_settings", None)
         if advanced_settings is not None:
             update_advanced_settings(ast.literal_eval(advanced_settings))
         aggregator_device_mapping = json.loads(aggregator_device_mapping)
@@ -73,13 +79,14 @@ def launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_
         }
 
         if GlobalConfig.IS_CANARY_NETWORK:
-            config_settings['start_date'] = \
-                instance((datetime.combine(date.today(), datetime.min.time())))
+            config_settings["start_date"] = (
+                instance((datetime.combine(date.today(), datetime.min.time()))))
 
         validate_global_settings(config_settings)
 
-        slot_length_realtime = duration(seconds=settings['slot_length_realtime'].seconds) \
-            if 'slot_length_realtime' in settings else None
+        slot_length_realtime = (
+            duration(seconds=settings["slot_length_realtime"].seconds)
+            if "slot_length_realtime" in settings else None)
 
         config = SimulationConfig(**config_settings)
 
@@ -107,12 +114,12 @@ def launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_
         elif scenario in available_simulation_scenarios:
             scenario_name = scenario
         else:
-            scenario_name = 'json_arg'
+            scenario_name = "json_arg"
             config.area = scenario
 
         kwargs = {"no_export": True,
                   "pricing_scheme": 0,
-                  "seed": settings.get('random_seed', 0)}
+                  "seed": settings.get("random_seed", 0)}
 
         gsy_e.constants.CONNECT_TO_PROFILES_DB = True
         gsy_e.constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ = True
@@ -124,8 +131,9 @@ def launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_
                        saved_sim_state=saved_state,
                        slot_length_realtime=slot_length_realtime,
                        kwargs=kwargs)
+    # pylint: disable=broad-except
     except Exception:
-        import traceback
+        # pylint: disable=import-outside-toplevel
         from gsy_e.gsy_e_core.redis_connections.redis_communication import publish_job_error_output
         publish_job_error_output(job_id, traceback.format_exc())
-        logging.getLogger().error(f"Error on jobId {job_id}: {traceback.format_exc()}")
+        logging.getLogger().exception("Error on jobId, %s", job_id)

--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -24,10 +24,10 @@ def decompress_and_decode_queued_strings(queued_string: bytes) -> Dict:
     return pickle.loads(decompress(queued_string))
 
 
-# pylint: disable=too-many-arguments, too-many-locals
 def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
                                   events: Optional[str], aggregator_device_mapping: str,
                                   saved_state: bytes, job_id: str):
+    # pylint: disable=too-many-arguments, too-many-locals
     """Launch simulation from rq job."""
     logging.getLogger().setLevel(logging.ERROR)
     scenario = decompress_and_decode_queued_strings(scenario)

--- a/src/gsy_e/gsy_e_core/util.py
+++ b/src/gsy_e/gsy_e_core/util.py
@@ -507,7 +507,8 @@ def convert_area_throughput_kVA_to_kWh(transfer_capacity_kWA, slot_length):
 def get_simulation_queue_name():
     """Get simulation queue name."""
     listen_to_cn = os.environ.get("LISTEN_TO_CANARY_NETWORK_REDIS_QUEUE", "no") == "yes"
-    return "canary_network" if listen_to_cn else "exchange"
+    return (ConstSettings.GeneralSettings.CN_JOB_QUEUE_NAME
+            if listen_to_cn else ConstSettings.GeneralSettings.SIM_JOB_QUEUE_NAME)
 
 
 class ExternalTickCounter:

--- a/src/gsy_e/models/config.py
+++ b/src/gsy_e/models/config.py
@@ -26,7 +26,7 @@ from pendulum import DateTime, Duration, duration, today
 
 from gsy_e.constants import TIME_ZONE
 from gsy_e.gsy_e_core.redis_connections.redis_area_market_communicator import (
-    ExternalConnectionCommunicator)
+    external_redis_communicator_factory)
 from gsy_e.gsy_e_core.util import change_global_config, format_interval
 
 
@@ -85,7 +85,7 @@ class SimulationConfig:
 
         self.capacity_kW = capacity_kW or ConstSettings.PVSettings.DEFAULT_CAPACITY_KW
         self.external_connection_enabled = external_connection_enabled
-        self.external_redis_communicator = ExternalConnectionCommunicator(
+        self.external_redis_communicator = external_redis_communicator_factory(
             external_connection_enabled)
         if aggregator_device_mapping is not None:
             self.external_redis_communicator.aggregator.set_aggregator_device_mapping(

--- a/src/gsy_e/models/config.py
+++ b/src/gsy_e/models/config.py
@@ -96,6 +96,7 @@ class SimulationConfig:
         return json.dumps(self.as_dict())
 
     def as_dict(self):
+        """Return config parameters as dict."""
         fields = {"sim_duration", "slot_length", "tick_length", "ticks_per_slot",
                   "total_ticks", "cloud_coverage", "capacity_kW", "grid_fee_type",
                   "external_connection_enabled", "enable_degrees_of_freedom"}
@@ -107,6 +108,7 @@ class SimulationConfig:
 
     def update_config_parameters(self, *, cloud_coverage=None, pv_user_profile=None,
                                  market_maker_rate=None, capacity_kW=None):
+        """Update provided config parameters."""
         if cloud_coverage is not None:
             self.cloud_coverage = cloud_coverage
         if pv_user_profile is not None:
@@ -117,6 +119,7 @@ class SimulationConfig:
             self.capacity_kW = capacity_kW
 
     def read_pv_user_profile(self, pv_user_profile=None):
+        """Read global pv user profile."""
         self.pv_user_profile = None \
             if pv_user_profile is None \
             else read_arbitrary_profile(InputProfileTypes.POWER,

--- a/src/gsy_e/models/myco_matcher/myco_external_matcher.py
+++ b/src/gsy_e/models/myco_matcher/myco_external_matcher.py
@@ -28,7 +28,7 @@ import gsy_e.constants
 from gsy_e.gsy_e_core.exceptions import (
     InvalidBidOfferPairException, MycoValidationException)
 from gsy_e.gsy_e_core.redis_connections.redis_area_market_communicator import (
-    ResettableCommunicator)
+    myco_redis_communicator_factory)
 from gsy_e.gsy_e_core.util import ExternalTickCounter
 from gsy_e.models.market.two_sided import TwoSidedMarket
 from gsy_e.models.myco_matcher.myco_matcher_interface import MycoMatcherInterface
@@ -69,7 +69,7 @@ class MycoExternalMatcher(MycoMatcherInterface):
         self._setup_redis_connection()
 
     def _setup_redis_connection(self):
-        self.myco_ext_conn = ResettableCommunicator()
+        self.myco_ext_conn = myco_redis_communicator_factory()
         self.myco_ext_conn.sub_to_multiple_channels(
             {"external-myco/simulation-id/": self.publish_simulation_id,
              f"{self._channel_prefix}/offers-bids/": self._publish_orders_message_buffer.append,

--- a/tests/market/test_myco_external_matcher.py
+++ b/tests/market/test_myco_external_matcher.py
@@ -27,9 +27,7 @@ class TestMycoExternalMatcher:
         cls.market = TwoSidedMarket(time_slot=now())
         cls.matcher.area_markets_mapping = {
             f"{cls.market_id}-{cls.market.time_slot_str}": cls.market}
-        cls.redis_connection = (
-            gsy_e.gsy_e_core.redis_connections.redis_area_market_communicator.
-            ResettableCommunicator)
+
         assert cls.matcher.simulation_id == gsy_e.constants.CONFIGURATION_ID
         cls.channel_prefix = f"external-myco/{gsy_e.constants.CONFIGURATION_ID}/"
         cls.events_channel = f"{cls.channel_prefix}events/"

--- a/tests/market/test_myco_external_matcher.py
+++ b/tests/market/test_myco_external_matcher.py
@@ -8,13 +8,14 @@ from pendulum import now
 import gsy_e.constants
 import gsy_e.models.market.market_redis_connection
 from gsy_e.gsy_e_core.exceptions import MycoValidationException, InvalidBidOfferPairException
+import gsy_e.gsy_e_core.redis_connections.redis_area_market_communicator
 from gsy_e.models.market import Offer, Bid
 from gsy_e.models.market.two_sided import TwoSidedMarket
 from gsy_e.models.myco_matcher import MycoExternalMatcher
 from gsy_e.models.myco_matcher.myco_external_matcher import MycoExternalMatcherValidator
 
-gsy_e.models.myco_matcher.myco_external_matcher.BlockingCommunicator = MagicMock
-gsy_e.models.myco_matcher.myco_external_matcher.ResettableCommunicator = MagicMock
+gsy_e.gsy_e_core.redis_connections.redis_area_market_communicator.ResettableCommunicator = (
+    MagicMock)
 
 
 class TestMycoExternalMatcher:
@@ -27,7 +28,8 @@ class TestMycoExternalMatcher:
         cls.matcher.area_markets_mapping = {
             f"{cls.market_id}-{cls.market.time_slot_str}": cls.market}
         cls.redis_connection = (
-            gsy_e.models.myco_matcher.myco_external_matcher.ResettableCommunicator)
+            gsy_e.gsy_e_core.redis_connections.redis_area_market_communicator.
+            ResettableCommunicator)
         assert cls.matcher.simulation_id == gsy_e.constants.CONFIGURATION_ID
         cls.channel_prefix = f"external-myco/{gsy_e.constants.CONFIGURATION_ID}/"
         cls.events_channel = f"{cls.channel_prefix}events/"


### PR DESCRIPTION
In order to make sure that only one consumer on the gsy-web side is handling each of the events and responses sent by the gsy-e, the communication was moved from redis pubsub to redis queue. This was done for both myco matcher and external devices and aggregators. For local simulation runs, the original pubsub way is kept. The constants.SEND_EVENTS_RESPONSES_TO_SDK_VIA_RQ is handling the switch between the two ways.
Also part of this PR: Centralised the queue names in the gsy-framework and reused them here.