### PR TITLE
GSYE-178: Enable grid fees accounting for DoF requirements

### DIFF
--- a/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
@@ -56,9 +56,9 @@ class TwoSidedEngine(MAEngine):
                     updated_requirement["original_price"] = updated_requirement["price"]
 
                 energy = updated_requirement.get("energy") or bid.energy
-                updated_price = (self.markets.source.fee_class.update_forwarded_bid_with_fee(
+                updated_price = self.markets.source.fee_class.update_forwarded_bid_with_fee(
                     updated_requirement["price"] / energy,
-                    updated_requirement["original_price"] / energy)) * energy
+                    updated_requirement["original_price"] / energy) * energy
                 updated_requirement["price"] = updated_price
             requirements.append(updated_requirement)
         return requirements

--- a/tests/strategies/test_strategy_storage.py
+++ b/tests/strategies/test_strategy_storage.py
@@ -180,7 +180,8 @@ class FakeMarket:
         return offer
 
     def bid(self, price, energy, buyer, market=None, original_price=None,
-            buyer_origin=None, buyer_origin_id=None, buyer_id=None):
+            buyer_origin=None, buyer_origin_id=None, buyer_id=None,
+            requirements=None, attributes=None):
         pass
 
 

--- a/tests/test_market_agent.py
+++ b/tests/test_market_agent.py
@@ -297,7 +297,8 @@ class TestMAGridFee:
     @pytest.mark.parametrize("market_agent_fee", [0.1, 0, 0.5, 0.75, 0.05, 0.02, 0.03])
     def test_ma_forwards_bids_according_to_percentage(market_agent_fee):
         ConstSettings.MASettings.MARKET_TYPE = 2
-        lower_market = FakeMarket([], [Bid("id", pendulum.now(), 1, 1, "this", 1)],
+        lower_market = FakeMarket([], [Bid("id", pendulum.now(), 1, 1, "this", 1,
+                                           requirements=[{"price": 2}])],
                                   transfer_fees=GridFee(grid_fee_percentage=market_agent_fee,
                                                         grid_fee_const=0),
                                   name="FakeMarket")
@@ -314,6 +315,10 @@ class TestMAGridFee:
         assert market_agent.higher_market.bid_call_count == 1
         assert (market_agent.higher_market.forwarded_bid.price ==
                 list(market_agent.lower_market.bids.values())[-1].price * (1 - market_agent_fee))
+
+        assert (market_agent.higher_market.forwarded_bid.requirements[0]["price"] ==
+                list(market_agent.lower_market.bids.values())[-1].requirements[0]["price"] * (
+                        1 - market_agent_fee))
 
     @staticmethod
     @pytest.mark.parametrize("market_agent_fee_const", [0.5, 1, 5, 10])

--- a/tests/test_market_agent.py
+++ b/tests/test_market_agent.py
@@ -187,7 +187,8 @@ class FakeMarket:
 
     def bid(self, price: float, energy: float, buyer: str,
             bid_id: str = None, original_price=None, buyer_origin=None,
-            adapt_price_with_fees=True, buyer_origin_id=None, buyer_id=None, time_slot=None):
+            adapt_price_with_fees=True, buyer_origin_id=None, buyer_id=None,
+            time_slot=None, requirements=None, attributes=None):
         self.bid_call_count += 1
 
         if original_price is None:
@@ -202,7 +203,7 @@ class FakeMarket:
         bid = Bid(bid_id, pendulum.now(), price, energy, buyer,
                   original_price=original_price,
                   buyer_origin=buyer_origin, buyer_origin_id=buyer_origin_id,
-                  buyer_id=buyer_id)
+                  buyer_id=buyer_id, requirements=requirements, attributes=attributes)
         self._bids.append(bid)
         self.forwarded_bid = bid
 

--- a/tests/test_two_sided_market.py
+++ b/tests/test_two_sided_market.py
@@ -100,6 +100,14 @@ class TestTwoSidedMarket:
         assert market.fee_class.update_incoming_bid_with_fee.called
 
     @staticmethod
+    def test_bid_with_requirements(market):
+        market.fee_class.update_incoming_bid_with_fee = MagicMock(return_value=5/2)
+        bid = market.bid(5, 2, "buyer", "buyer_origin", bid_id="my_bid",
+                         requirements=[{"price": 1}])
+
+        assert bid.requirements[0]["price"] == 5
+
+    @staticmethod
     def test_delete_bid(market):
         """Test the delete_bid method of TwoSidedMarket."""
         bid1 = Bid("bid1", pendulum.now(), 9, 10, "B", 9,


### PR DESCRIPTION
We used to add grid fees to the orders' prices when they get forwarded to another market.
Now that the orders have other `price` source of truth (the ones in the requirements), when we add fees to the order.price we also have to add fees to all `price` key in all `order.requirements` list (otherwise offer seller may end up getting less than it requested)