### PR TITLE
GSYE-6: Forward residual offers and bids by the market agents at the …

### DIFF
--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -426,9 +426,11 @@ class TwoSidedMarket(OneSidedMarket):
         """
 
         def replace_recommendations_with_residuals(recommendation: Dict):
-            if recommendation["offer"]["id"] == offer_trade.offer_bid.id:
+            if (recommendation["offer"]["id"] == offer_trade.offer_bid.id and
+                    offer_trade.residual is not None):
                 recommendation["offer"] = offer_trade.residual.serializable_dict()
-            if recommendation["bid"]["id"] == bid_trade.offer_bid.id:
+            if (recommendation["bid"]["id"] == bid_trade.offer_bid.id and
+                    bid_trade.residual is not None):
                 recommendation["bid"] = bid_trade.residual.serializable_dict()
             return recommendation
 

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -284,6 +284,17 @@ class TwoSidedMarket(OneSidedMarket):
                                     seller_id=offer.seller_id)
         return bid_trade, trade
 
+    def _get_offer_from_seller_origin_id(self, seller_origin_id):
+        """Get the first offer that has the same seller_origin_id."""
+        return next(iter(
+            [offer for offer in self.offers.values()
+             if offer.seller_origin_id == seller_origin_id]), None)
+
+    def _get_bid_from_buyer_origin_id(self, buyer_origin_id):
+        return next(iter(
+            [bid for bid in self.bids.values()
+             if bid.buyer_origin_id == buyer_origin_id]), None)
+
     def match_recommendations(
             self, recommendations: List[BidOfferMatch.serializable_dict]) -> bool:
         """Match a list of bid/offer pairs, create trades and residual offers/bids.
@@ -293,6 +304,24 @@ class TwoSidedMarket(OneSidedMarket):
             recommended_pair = BidOfferMatch.from_dict(recommendations.pop(0))
             market_offer = self.offers.get(recommended_pair.offer["id"])
             market_bid = self.bids.get(recommended_pair.bid["id"])
+
+            # TODO: This is a temporary solution based on the fact that trading strategies do not
+            # post multiple bids or offers on the same market at the moment. Will be shortly
+            # replaced by a global offer / bid identifier instead of tracking the original order
+            # by seller / buyer.
+            if not market_offer:
+                market_offer = self._get_offer_from_seller_origin_id(
+                    recommended_pair.offer["seller_origin_id"])
+                if market_offer is None:
+                    raise InvalidBidOfferPairException("Offer does not exist in the market")
+                recommended_pair.offer = market_offer.serializable_dict()
+            if not market_bid:
+                market_bid = self._get_bid_from_buyer_origin_id(
+                    recommended_pair.bid["buyer_origin_id"])
+                if market_bid is None:
+                    raise InvalidBidOfferPairException("Bid does not exist in the market")
+                recommended_pair.bid = market_bid.serializable_dict()
+
             try:
                 self.validate_bid_offer_match(recommended_pair)
             except InvalidBidOfferPairException as invalid_bop_exception:

--- a/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
@@ -197,6 +197,10 @@ class MAEngine:
 
             self._delete_forwarded_offer_entries(offer_info.source_offer)
             self.offer_age.pop(offer_info.source_offer.id, None)
+
+            # Forward the residual offer since the original offer was also forwarded
+            if trade.residual:
+                self._forward_offer(trade.residual)
         else:
             raise RuntimeError("Unknown state. Can't happen")
 

--- a/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
@@ -168,8 +168,13 @@ class TwoSidedEngine(MAEngine):
 
         elif bid_trade.offer_bid.id == bid_info.source_bid.id:
             # Bid was traded in the source market by someone else
+
             self._delete_forwarded_bids(bid_info)
             self.bid_age.pop(bid_info.source_bid.id, None)
+
+            # Forward the residual bid since the original offer was also forwarded
+            if bid_trade.residual:
+                self._forward_bid(bid_trade.residual)
         else:
             raise Exception(f"Invalid bid state for MA {self.owner.name}: "
                             f"traded bid {bid_trade} was not in offered bids tuple {bid_info}")

--- a/src/gsy_e/setup/kpi/d3asim_2103_2_sided_pab.py
+++ b/src/gsy_e/setup/kpi/d3asim_2103_2_sided_pab.py
@@ -13,8 +13,8 @@ def get_setup(config):
 
     ConstSettings.GeneralSettings.DEFAULT_UPDATE_INTERVAL = 1
     ConstSettings.MASettings.MARKET_TYPE = 2
-    ConstSettings.MASettings.MIN_BID_AGE = 0
-    ConstSettings.MASettings.MIN_OFFER_AGE = 0
+    ConstSettings.MASettings.MIN_BID_AGE = 1
+    ConstSettings.MASettings.MIN_OFFER_AGE = 1
 
     area = Area(
         "Grid",


### PR DESCRIPTION
…time of the trade event, if the original offer or bid was also forwarded. Adapted the two-sided market recommendation matcher to check whether another offer or bid from the same original seller or buyer exists in the market, and use it in case the offer / bid from the recommendation does not exist in the market, in order to cover the case that the market bid / offer was deleted because it was traded in another market.

The root cause of the problem were that some of the Myco recommendations were marked as failed at the time of the market clearing, because they were forwarded offers / bids and their origin was traded in another recommendation, thus deleting them from the markets. 

The fix consists of 2 parts. First, when an order is traded, and the related forwarded orders are deleted from all markets, the new residual order needs to be reforwarded immediately to the markets, so that the recommendation set has at least the new residual orders available to be used instead of the original and clear successfully. Second, the clearing mechanism should be able to track the residual version of the original order in case the order is not found in the market. The current PR deals with that by tracking the buyer / seller id and abusing the case that there is only one bid / offer per seller / buyer and market slot. The correct solution would be to add a global identifier for the order, that will be used in order to track if the residual order is a byproduct of the original with the same origin id. This will be dealt by this ticket https://gridsingularity.atlassian.net/browse/GSYE-182 