### PR TITLE
 Update PV energy availability in future markets

### DIFF
--- a/src/gsy_e/models/strategy/external_strategies/pv.py
+++ b/src/gsy_e/models/strategy/external_strategies/pv.py
@@ -46,7 +46,9 @@ class PVExternalMixin(ExternalMixin):
     offers: "Offers"
     can_offer_be_posted: Callable
     post_offer: Callable
-    set_produced_energy_forecast_kWh_future_markets: Callable
+    set_produced_energy_forecast_kWh_in_state: Callable
+    set_produced_energy_forecast_kWh_spot_market: Callable
+    set_produced_energy_forecast_kWh_future_market: Callable
     _delete_past_state: Callable
 
     @property
@@ -218,7 +220,7 @@ class PVExternalMixin(ExternalMixin):
         self._reject_all_pending_requests()
         self._update_connection_status()
         if not self.should_use_default_strategy:
-            self.set_produced_energy_forecast_kWh_future_markets(reconfigure=False)
+            self.set_produced_energy_forecast_kWh_in_state(reconfigure=False)
             self._set_energy_measurement_of_last_market()
             if not self.is_aggregator_controlled:
                 market_event_channel = f"{self.channel_prefix}/events/market"
@@ -429,11 +431,15 @@ class PVForecastExternalStrategy(ForecastExternalMixin, PVPredefinedExternalStra
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
 
-    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=False) -> None:
+    def set_produced_energy_forecast_kWh_spot_market(self, reconfigure=False) -> None:
         """
         Setting produced energy for the next slot is already done by update_energy_forecast
         """
 
+    def set_produced_energy_forecast_kWh_future_market(self, reconfigure=False) -> None:
+        """
+        Setting produced energy for the future slots is already done by update_energy_forecast
+        """
     def _set_energy_measurement_of_last_market(self):
         """
          Setting energy measurement for the previous slot is already done by

--- a/src/gsy_e/models/strategy/external_strategies/pv.py
+++ b/src/gsy_e/models/strategy/external_strategies/pv.py
@@ -46,9 +46,7 @@ class PVExternalMixin(ExternalMixin):
     offers: "Offers"
     can_offer_be_posted: Callable
     post_offer: Callable
-    set_produced_energy_forecast_kWh_in_state: Callable
-    set_produced_energy_forecast_kWh_spot_market: Callable
-    set_produced_energy_forecast_kWh_future_market: Callable
+    set_produced_energy_forecast_in_state: Callable
     _delete_past_state: Callable
 
     @property
@@ -220,7 +218,7 @@ class PVExternalMixin(ExternalMixin):
         self._reject_all_pending_requests()
         self._update_connection_status()
         if not self.should_use_default_strategy:
-            self.set_produced_energy_forecast_kWh_in_state(reconfigure=False)
+            self.set_produced_energy_forecast_in_state(reconfigure=False)
             self._set_energy_measurement_of_last_market()
             if not self.is_aggregator_controlled:
                 market_event_channel = f"{self.channel_prefix}/events/market"
@@ -431,15 +429,11 @@ class PVForecastExternalStrategy(ForecastExternalMixin, PVPredefinedExternalStra
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
 
-    def set_produced_energy_forecast_kWh_spot_market(self, reconfigure=False) -> None:
+    def set_produced_energy_forecast_in_state(self, reconfigure=False) -> None:
         """
         Setting produced energy for the next slot is already done by update_energy_forecast
         """
 
-    def set_produced_energy_forecast_kWh_future_market(self, reconfigure=False) -> None:
-        """
-        Setting produced energy for the future slots is already done by update_energy_forecast
-        """
     def _set_energy_measurement_of_last_market(self):
         """
          Setting energy measurement for the previous slot is already done by

--- a/src/gsy_e/models/strategy/predefined_pv.py
+++ b/src/gsy_e/models/strategy/predefined_pv.py
@@ -92,9 +92,9 @@ class PVPredefinedStrategy(PVStrategy):
     def read_config_event(self):
         # this is to trigger to read from self.simulation_config.cloud_coverage:
         self.cloud_coverage = None
-        self.set_produced_energy_forecast_kWh_future_markets(reconfigure=True)
+        self.set_produced_energy_forecast_kWh_in_state(reconfigure=True)
 
-    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=True):
+    def set_produced_energy_forecast_kWh_spot_market(self, reconfigure=True):
         self._power_profile_index = self.cloud_coverage \
             if self.cloud_coverage is not None else self.simulation_config.cloud_coverage
         if reconfigure:
@@ -213,7 +213,7 @@ class PVUserProfileStrategy(PVPredefinedStrategy):
         if key_in_dict_and_not_none(kwargs, 'power_profile'):
             self._power_profile_input = kwargs['power_profile']
         self._read_or_rotate_profiles(reconfigure=True)
-        self.set_produced_energy_forecast_kWh_future_markets(reconfigure=True)
+        self.set_produced_energy_forecast_kWh_in_state(reconfigure=True)
 
     def event_market_cycle(self):
         self._read_predefined_profile_for_pv()

--- a/src/gsy_e/models/strategy/predefined_pv.py
+++ b/src/gsy_e/models/strategy/predefined_pv.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import pathlib
 
-from gsy_framework.constants_limits import ConstSettings
+from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.read_user_profile import read_arbitrary_profile, InputProfileTypes
 from gsy_framework.utils import convert_kW_to_kWh
 from gsy_framework.utils import key_in_dict_and_not_none, find_object_of_same_weekday_and_time
@@ -92,22 +92,23 @@ class PVPredefinedStrategy(PVStrategy):
     def read_config_event(self):
         # this is to trigger to read from self.simulation_config.cloud_coverage:
         self.cloud_coverage = None
-        self.set_produced_energy_forecast_kWh_in_state(reconfigure=True)
+        self.set_produced_energy_forecast_in_state(reconfigure=True)
 
-    def set_produced_energy_forecast_kWh_spot_market(self, reconfigure=True):
-        self._power_profile_index = self.cloud_coverage \
-            if self.cloud_coverage is not None else self.simulation_config.cloud_coverage
+    def set_produced_energy_forecast_in_state(self, reconfigure=True):
+        self._power_profile_index = self.cloud_coverage or self.simulation_config.cloud_coverage
         if reconfigure:
             self._read_predefined_profile_for_pv()
-        market = self.area.spot_market
-        slot_time = market.time_slot
         if not self.energy_profile:
             raise GSyException(
                 f"PV {self.owner.name} tries to set its available energy forecast without a "
-                f"power profile.")
-        available_energy_kWh = find_object_of_same_weekday_and_time(
-            self.energy_profile, slot_time) * self.panel_count
-        self.state.set_available_energy(available_energy_kWh, slot_time, reconfigure)
+                "power profile.")
+        time_slots = [self.area.spot_market.time_slot]
+        if GlobalConfig.FUTURE_MARKET_DURATION_HOURS:
+            time_slots.extend(self.area.future_market_time_slots)
+        for time_slot in time_slots:
+            available_energy_kWh = find_object_of_same_weekday_and_time(
+                self.energy_profile, time_slot) * self.panel_count
+            self.state.set_available_energy(available_energy_kWh, time_slot, reconfigure)
 
     def _read_predefined_profile_for_pv(self):
         """
@@ -213,7 +214,7 @@ class PVUserProfileStrategy(PVPredefinedStrategy):
         if key_in_dict_and_not_none(kwargs, 'power_profile'):
             self._power_profile_input = kwargs['power_profile']
         self._read_or_rotate_profiles(reconfigure=True)
-        self.set_produced_energy_forecast_kWh_in_state(reconfigure=True)
+        self.set_produced_energy_forecast_in_state(reconfigure=True)
 
     def event_market_cycle(self):
         self._read_predefined_profile_for_pv()

--- a/src/gsy_e/models/strategy/pv.py
+++ b/src/gsy_e/models/strategy/pv.py
@@ -19,7 +19,8 @@ import math
 import traceback
 from logging import getLogger
 
-from gsy_framework.constants_limits import ConstSettings
+import pendulum
+from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.read_user_profile import read_arbitrary_profile, InputProfileTypes
 from gsy_framework.utils import (
     convert_kW_to_kWh, find_object_of_same_weekday_and_time, key_in_dict_and_not_none)
@@ -121,7 +122,7 @@ class PVStrategy(BidEnabledStrategy):
         if key_in_dict_and_not_none(kwargs, "capacity_kW"):
             self.capacity_kW = kwargs["capacity_kW"]
 
-        self.set_produced_energy_forecast_kWh_future_markets(reconfigure=True)
+        self.set_produced_energy_forecast_kWh_in_state(reconfigure=True)
 
     def _area_reconfigure_prices(self, **kwargs):
         if key_in_dict_and_not_none(kwargs, "initial_selling_rate"):
@@ -208,7 +209,7 @@ class PVStrategy(BidEnabledStrategy):
     def event_activate_energy(self):
         if self.capacity_kW is None:
             self.capacity_kW = self.simulation_config.capacity_kW
-        self.set_produced_energy_forecast_kWh_future_markets(reconfigure=True)
+        self.set_produced_energy_forecast_kWh_in_state(reconfigure=True)
 
     def event_tick(self):
         """Update the prices of existing offers on market tick.
@@ -221,17 +222,32 @@ class PVStrategy(BidEnabledStrategy):
         self._settlement_market_strategy.event_tick(self)
         self._future_market_strategy.event_tick(self)
 
-    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=True):
+    def set_produced_energy_forecast_kWh_in_state(self, reconfigure=True):
+        self.set_produced_energy_forecast_kWh_spot_market(reconfigure)
+        self.set_produced_energy_forecast_kWh_future_market(reconfigure)
+
+    def set_produced_energy_forecast_kWh_spot_market(self, reconfigure=True):
         # This forecast is based on the real PV system data provided by enphase
         # They can be found in the tools folder
         # A fit of a gaussian function to those data results in a formula Energy(time)
         market = self.area.spot_market
         slot_time = market.time_slot
-        difference_to_midnight_in_minutes = \
-            slot_time.diff(self.area.now.start_of("day")).in_minutes() % (60 * 24)
+        difference_to_midnight_in_minutes = slot_time.diff(
+            self.area.now.start_of("day")).in_minutes() % (60 * 24)
         available_energy_kWh = self.gaussian_energy_forecast_kWh(
             difference_to_midnight_in_minutes) * self.panel_count
-        self.state.set_available_energy(available_energy_kWh, slot_time, reconfigure)
+        self.state.set_available_energy(available_energy_kWh, slot_time, True)
+
+    def set_produced_energy_forecast_kWh_future_market(self, reconfigure=True):
+        if not GlobalConfig.FUTURE_MARKET_DURATION_HOURS:
+            return
+        for slot_time in self.area.future_market_time_slots:
+            difference_to_midnight_in_minutes = slot_time.diff(
+                pendulum.datetime(
+                    slot_time.year, slot_time.month, slot_time.day)).in_minutes() % (60 * 24)
+            available_energy_kWh = self.gaussian_energy_forecast_kWh(
+                difference_to_midnight_in_minutes) * self.panel_count
+            self.state.set_available_energy(available_energy_kWh, slot_time, reconfigure)
 
     def gaussian_energy_forecast_kWh(self, time_in_minutes=0):
         # The sun rises at approx 6:30 and sets at 18hr
@@ -258,7 +274,7 @@ class PVStrategy(BidEnabledStrategy):
         super().event_market_cycle()
         # Provide energy values for the past market slot, to be used in the settlement market
         self._set_energy_measurement_of_last_market()
-        self.set_produced_energy_forecast_kWh_future_markets(reconfigure=False)
+        self.set_produced_energy_forecast_kWh_in_state(reconfigure=False)
         self._set_alternative_pricing_scheme()
         self.event_market_cycle_price()
         self._delete_past_state()
@@ -289,7 +305,6 @@ class PVStrategy(BidEnabledStrategy):
         self.offer_update.update_and_populate_price_settings(self.area)
         self.offer_update.reset(self)
 
-        # Iterate over all markets open in the future
         market = self.area.spot_market
         offer_energy_kWh = self.state.get_available_energy_kWh(market.time_slot)
         # We need to subtract the energy from the offers that are already posted in this

--- a/tests/strategies/test_strategy_pv.py
+++ b/tests/strategies/test_strategy_pv.py
@@ -356,7 +356,7 @@ def testing_produced_energy_forecast_real_data(pv_test66):
     # prepare whole day of energy_production_forecast_kWh:
     for time_slot in generate_market_slot_list():
         pv_test66.area.create_spot_market(time_slot)
-        pv_test66.set_produced_energy_forecast_kWh_future_markets(reconfigure=False)
+        pv_test66.set_produced_energy_forecast_kWh_in_state(reconfigure=False)
     morning_time = pendulum.today(tz=TIME_ZONE).at(hour=8, minute=20, second=0)
     afternoon_time = pendulum.today(tz=TIME_ZONE).at(hour=16, minute=40, second=0)
 

--- a/tests/strategies/test_strategy_pv.py
+++ b/tests/strategies/test_strategy_pv.py
@@ -356,7 +356,7 @@ def testing_produced_energy_forecast_real_data(pv_test66):
     # prepare whole day of energy_production_forecast_kWh:
     for time_slot in generate_market_slot_list():
         pv_test66.area.create_spot_market(time_slot)
-        pv_test66.set_produced_energy_forecast_kWh_in_state(reconfigure=False)
+        pv_test66.set_produced_energy_forecast_in_state(reconfigure=False)
     morning_time = pendulum.today(tz=TIME_ZONE).at(hour=8, minute=20, second=0)
     afternoon_time = pendulum.today(tz=TIME_ZONE).at(hour=16, minute=40, second=0)
 

--- a/tests/strategies/test_strategy_pvpredefined.py
+++ b/tests/strategies/test_strategy_pvpredefined.py
@@ -287,7 +287,7 @@ def testing_produced_energy_forecast_real_data(pv_test66):
     # prepare whole day of energy_production_forecast_kWh:
     for time_slot in generate_market_slot_list():
         pv_test66.area.create_spot_market(time_slot)
-        pv_test66.set_produced_energy_forecast_kWh_in_state(reconfigure=False)
+        pv_test66.set_produced_energy_forecast_in_state(reconfigure=False)
 
     morning_time = pendulum.today(tz=TIME_ZONE).at(hour=5, minute=10, second=0)
     afternoon_time = pendulum.today(tz=TIME_ZONE).at(hour=19, minute=10, second=0)

--- a/tests/strategies/test_strategy_pvpredefined.py
+++ b/tests/strategies/test_strategy_pvpredefined.py
@@ -287,7 +287,7 @@ def testing_produced_energy_forecast_real_data(pv_test66):
     # prepare whole day of energy_production_forecast_kWh:
     for time_slot in generate_market_slot_list():
         pv_test66.area.create_spot_market(time_slot)
-        pv_test66.set_produced_energy_forecast_kWh_future_markets(reconfigure=False)
+        pv_test66.set_produced_energy_forecast_kWh_in_state(reconfigure=False)
 
     morning_time = pendulum.today(tz=TIME_ZONE).at(hour=5, minute=10, second=0)
     afternoon_time = pendulum.today(tz=TIME_ZONE).at(hour=19, minute=10, second=0)


### PR DESCRIPTION
The PV's strategy was not updating the energy availability for the future market, this PR adds the setter method ` set_produced_energy_forecast_kWh_future_market` for the future markets.
There is also another added method ` set_produced_energy_forecast_kWh_in_state` that basically wraps both the setter calls for the spot market and the future markets