### PR TITLE
GSYE-154: Read the bid's requirement price when matching with DoF

### DIFF
--- a/src/gsy_e/models/market/grid_fees/__init__.py
+++ b/src/gsy_e/models/market/grid_fees/__init__.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from abc import ABC, abstractmethod
-from typing import Tuple
+from typing import Tuple, Optional
 
 from gsy_framework.data_classes import TradeBidOfferInfo, Bid, Offer
 
@@ -48,37 +48,10 @@ class BaseClassGridFees(ABC):
         """Add fees for offer's rate when it's forwarded by another market."""
 
     @abstractmethod
-    def update_forwarded_bid_trade_original_info(
-            self, trade_original_info: TradeBidOfferInfo, market_bid: Bid) -> TradeBidOfferInfo:
-        """
-        When a forwarded bid gets matched in a target market, it will also get matched in
-        the source market with adjustments to the TradeBidOfferInfo of this trade.
-        This method deals with duplicating and updating the TradeBidOfferInfo values.
-        Args:
-            trade_original_info: TradeBidOfferInfo instance created in the target market
-            market_bid: the source bid instance that was cleared in a target market.
-
-        Returns: TradeBidOfferInfo
-        """
-
-    @abstractmethod
-    def update_forwarded_offer_trade_original_info(
-            self, trade_original_info: TradeBidOfferInfo, market_offer: Offer
-    ) -> TradeBidOfferInfo:
-        """
-        When a forwarded offer gets matched in a target market, it will also get matched in
-        the source market with adjustments to the TradeBidOfferInfo of this trade.
-        This method deals with duplicating and updating the TradeBidOfferInfo values.
-        Args:
-            trade_original_info: TradeBidOfferInfo instance created in the target market
-            market_offer: the source offer instance that was cleared in a target market.
-
-        Returns: TradeBidOfferInfo
-        """
-
-    @abstractmethod
-    def propagate_original_bid_info_on_offer_trade(self, trade_original_info):
-        """Add fees to the cleared bid trade.
+    def adapt_bid_fees_on_bid_trade(
+            self, trade_original_info: TradeBidOfferInfo, market_bid: Bid
+    ) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+        """Add fees to the bid of the cleared bid trade.
 
         The reason we recalculate fees on trade even when we initially have these fees
         on the orders when they got forwarded is that the clearing rate is not always
@@ -86,8 +59,29 @@ class BaseClassGridFees(ABC):
         """
 
     @abstractmethod
-    def propagate_original_offer_info_on_bid_trade(self, trade_original_info, ignore_fees=False):
-        """Add fees to the cleared offer trade.
+    def adapt_offer_fees_on_offer_trade(
+            self, trade_original_info: TradeBidOfferInfo, market_offer: Offer
+    ) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+        """Add fees to the offer of the cleared offer trade.
+
+        The reason we recalculate fees on trade even when we initially have these fees
+        on the orders when they got forwarded is that the clearing rate is not always
+        the offer or bid rate, It might change depending on the algorithm.
+        """
+
+    @abstractmethod
+    def adapt_bid_fees_on_offer_trade(
+            self, trade_original_info) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+        """Add fees to the bid of the cleared offer trade.
+
+        The reason we recalculate fees on trade even when we initially have these fees
+        on the orders when they got forwarded is that the clearing rate is not always
+        the offer or bid rate, It might change depending on the algorithm.
+        """
+
+    @abstractmethod
+    def adapt_offer_fees_on_bid_trade(self, trade_original_info, ignore_fees=False):
+        """Add fees to the offer of the cleared bid trade.
 
         The reason we recalculate fees on trade even when we initially have these fees
         on the orders when they got forwarded is that the clearing rate is not always

--- a/src/gsy_e/models/market/grid_fees/base_model.py
+++ b/src/gsy_e/models/market/grid_fees/base_model.py
@@ -15,8 +15,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from gsy_framework.data_classes import TradeBidOfferInfo
-
 from gsy_e.models.market.grid_fees import BaseClassGridFees
 
 

--- a/src/gsy_e/models/market/grid_fees/base_model.py
+++ b/src/gsy_e/models/market/grid_fees/base_model.py
@@ -61,54 +61,33 @@ class GridFees(BaseClassGridFees):
     def update_forwarded_offer_with_fee(self, source_rate, _):
         return source_rate
 
-    def update_forwarded_bid_trade_original_info(self, trade_original_info, market_bid):
+    def adapt_bid_fees_on_bid_trade(self, trade_original_info, market_bid):
         if not trade_original_info:
-            return None
-        trade_offer_info = TradeBidOfferInfo(
-            original_bid_rate=market_bid.original_price / market_bid.energy,
-            propagated_bid_rate=market_bid.energy_rate,
-            original_offer_rate=trade_original_info.original_offer_rate,
-            propagated_offer_rate=trade_original_info.propagated_offer_rate,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_offer_info
+            return None, None, None
+        original_bid_rate = market_bid.original_price / market_bid.energy
+        return original_bid_rate, market_bid.energy_rate, trade_original_info.trade_rate
 
-    def update_forwarded_offer_trade_original_info(self, trade_original_info, market_offer):
+    def adapt_offer_fees_on_offer_trade(self, trade_original_info, market_offer):
         if not trade_original_info:
-            return None
-        trade_bid_info = TradeBidOfferInfo(
-            original_bid_rate=trade_original_info.original_bid_rate,
-            propagated_bid_rate=trade_original_info.propagated_bid_rate,
-            original_offer_rate=market_offer.original_price / market_offer.energy,
-            propagated_offer_rate=market_offer.energy_rate,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_bid_info
+            return None, None, None
+        original_offer_rate = market_offer.original_price / market_offer.energy
+        return original_offer_rate, market_offer.energy_rate, trade_original_info.trade_rate
 
-    def propagate_original_bid_info_on_offer_trade(self, trade_original_info):
+    def adapt_bid_fees_on_offer_trade(self, trade_original_info):
         if trade_original_info is None:
-            return None
+            return None, None, None
         bid_rate = (
                 trade_original_info.propagated_bid_rate
                 - trade_original_info.original_bid_rate * self.grid_fee_rate)
-        trade_bid_info = TradeBidOfferInfo(
-            original_bid_rate=trade_original_info.original_bid_rate,
-            propagated_bid_rate=bid_rate,
-            original_offer_rate=None,
-            propagated_offer_rate=None,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_bid_info
+        original_bid_rate = trade_original_info.original_bid_rate
+        return original_bid_rate, bid_rate, trade_original_info.trade_rate
 
-    def propagate_original_offer_info_on_bid_trade(self, trade_original_info, ignore_fees=False):
+    def adapt_offer_fees_on_bid_trade(self, trade_original_info, ignore_fees=False):
         grid_fee_rate = self.grid_fee_rate if not ignore_fees else 0.0
         offer_rate = (
                 trade_original_info.propagated_offer_rate
                 + trade_original_info.original_offer_rate * grid_fee_rate)
-        trade_offer_info = TradeBidOfferInfo(
-            original_bid_rate=None,
-            propagated_bid_rate=None,
-            original_offer_rate=trade_original_info.original_offer_rate,
-            propagated_offer_rate=offer_rate,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_offer_info
+        return trade_original_info.original_offer_rate, offer_rate, trade_original_info.trade_rate
 
     def calculate_trade_price_and_fees(self, trade_bid_info):
         revenue, grid_fee_rate, trade_price = self._calculate_fee_revenue_from_clearing_trade(

--- a/src/gsy_e/models/market/grid_fees/constant_grid_fees.py
+++ b/src/gsy_e/models/market/grid_fees/constant_grid_fees.py
@@ -15,8 +15,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from gsy_framework.data_classes import TradeBidOfferInfo
-
 from gsy_e.models.market.grid_fees import BaseClassGridFees
 
 

--- a/src/gsy_e/models/market/grid_fees/constant_grid_fees.py
+++ b/src/gsy_e/models/market/grid_fees/constant_grid_fees.py
@@ -47,50 +47,35 @@ class ConstantGridFees(BaseClassGridFees):
     def update_forwarded_offer_with_fee(self, source_rate, original_rate):
         return source_rate
 
-    def update_forwarded_bid_trade_original_info(self, trade_original_info, market_bid):
+    def adapt_bid_fees_on_bid_trade(self, trade_original_info, market_bid):
         if not trade_original_info:
-            return None
-        trade_offer_info = TradeBidOfferInfo(
-            original_bid_rate=market_bid.original_price / market_bid.energy,
-            propagated_bid_rate=market_bid.energy_rate,
-            original_offer_rate=trade_original_info.original_offer_rate,
-            propagated_offer_rate=trade_original_info.propagated_offer_rate,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_offer_info
+            return None, None, None
+        if trade_original_info.propagated_bid_rate:
+            # When DoF is active, read the rate used in the trade market adding the current
+            # market's grid fee
+            propagated_bid_rate = trade_original_info.propagated_bid_rate + self.grid_fee_rate
+        else:
+            propagated_bid_rate = market_bid.energy_rate + self.grid_fee_rate
+        return (
+            trade_original_info.original_bid_rate, propagated_bid_rate,
+            trade_original_info.trade_rate)
 
-    def update_forwarded_offer_trade_original_info(self, trade_original_info, market_offer):
+    def adapt_offer_fees_on_offer_trade(self, trade_original_info, market_offer):
         if not trade_original_info:
-            return None
-        trade_bid_info = TradeBidOfferInfo(
-            original_bid_rate=trade_original_info.original_bid_rate,
-            propagated_bid_rate=trade_original_info.propagated_bid_rate,
-            original_offer_rate=market_offer.original_price / market_offer.energy,
-            propagated_offer_rate=market_offer.energy_rate,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_bid_info
+            return None, None, None
+        original_offer_rate = market_offer.original_price / market_offer.energy
+        return original_offer_rate, market_offer.energy_rate, trade_original_info.trade_rate
 
-    def propagate_original_bid_info_on_offer_trade(self, trade_original_info):
+    def adapt_bid_fees_on_offer_trade(self, trade_original_info):
         if trade_original_info is None:
-            return None
+            return None, None, None
         bid_rate = trade_original_info.propagated_bid_rate - self.grid_fee_rate
-        trade_bid_info = TradeBidOfferInfo(
-            original_bid_rate=trade_original_info.original_bid_rate,
-            propagated_bid_rate=bid_rate,
-            original_offer_rate=None,
-            propagated_offer_rate=None,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_bid_info
+        return trade_original_info.original_bid_rate, bid_rate, trade_original_info.trade_rate
 
-    def propagate_original_offer_info_on_bid_trade(self, trade_original_info, ignore_fees=False):
+    def adapt_offer_fees_on_bid_trade(self, trade_original_info, ignore_fees=False):
         grid_fee_rate = self.grid_fee_rate if not ignore_fees else 0.0
         offer_rate = trade_original_info.propagated_offer_rate + grid_fee_rate
-        trade_offer_info = TradeBidOfferInfo(
-            original_bid_rate=None,
-            propagated_bid_rate=None,
-            original_offer_rate=trade_original_info.original_offer_rate,
-            propagated_offer_rate=offer_rate,
-            trade_rate=trade_original_info.trade_rate)
-        return trade_offer_info
+        return trade_original_info.original_offer_rate, offer_rate, trade_original_info.trade_rate
 
     def calculate_trade_price_and_fees(self, trade_bid_info):
         bid_rate = trade_bid_info.propagated_bid_rate

--- a/src/gsy_e/models/market/one_sided.py
+++ b/src/gsy_e/models/market/one_sided.py
@@ -307,12 +307,18 @@ class OneSidedMarket(MarketBase):
 
         # Delete the accepted offer from self.offers:
         self.offers.pop(offer.id, None)
-        offer_bid_trade_info = self.fee_class.propagate_original_bid_info_on_offer_trade(
-            trade_original_info=trade_bid_info)
+        original_bid_rate, propagated_bid_rate, clearing_rate = (
+            self.fee_class.adapt_bid_fees_on_offer_trade(
+                trade_original_info=trade_bid_info)
+        )
+        orders_trade_info = TradeBidOfferInfo(
+            original_bid_rate, propagated_bid_rate,
+            trade_bid_info.original_offer_rate if trade_bid_info else None,
+            trade_bid_info.propagated_offer_rate if trade_bid_info else None, clearing_rate)
 
         trade = Trade(trade_id, self.now, offer, offer.seller, buyer,
                       traded_energy=energy, trade_price=trade_price, residual=residual_offer,
-                      offer_bid_trade_info=offer_bid_trade_info,
+                      offer_bid_trade_info=orders_trade_info,
                       seller_origin=offer.seller_origin, buyer_origin=buyer_origin,
                       fee_price=fee_price, buyer_origin_id=buyer_origin_id,
                       seller_origin_id=offer.seller_origin_id,

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -344,15 +344,16 @@ class TwoSidedMarket(OneSidedMarket):
                     # re-raise exception to be handled by the external matcher
                     raise invalid_bop_exception
                 continue
-            original_bid_rate = market_bid.original_price / market_bid.energy
+            original_bid_rate = recommended_pair.bid_energy_rate - market_bid.accumulated_grid_fees
             if ConstSettings.MASettings.BID_OFFER_MATCH_TYPE == BidOfferMatchAlgoEnum.PAY_AS_BID:
                 trade_rate = original_bid_rate
             else:
                 trade_rate = self.fee_class.calculate_original_trade_rate_from_clearing_rate(
-                    original_bid_rate, market_bid.energy_rate, recommended_pair.trade_rate)
+                    original_bid_rate, recommended_pair.bid_energy_rate,
+                    recommended_pair.trade_rate)
             trade_bid_info = TradeBidOfferInfo(
                 original_bid_rate=original_bid_rate,
-                propagated_bid_rate=market_bid.energy_rate,
+                propagated_bid_rate=recommended_pair.bid_energy_rate,
                 original_offer_rate=market_offer.original_price / market_offer.energy,
                 propagated_offer_rate=market_offer.energy_rate,
                 trade_rate=trade_rate)

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -344,7 +344,8 @@ class TwoSidedMarket(OneSidedMarket):
                     # re-raise exception to be handled by the external matcher
                     raise invalid_bop_exception
                 continue
-            original_bid_rate = recommended_pair.bid_energy_rate - market_bid.accumulated_grid_fees
+            original_bid_rate = recommended_pair.bid_energy_rate - (
+                market_bid.accumulated_grid_fees / recommended_pair.bid_energy)
             if ConstSettings.MASettings.BID_OFFER_MATCH_TYPE == BidOfferMatchAlgoEnum.PAY_AS_BID:
                 trade_rate = original_bid_rate
             else:

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -249,14 +249,14 @@ class TwoSidedMarket(OneSidedMarket):
 
         # Do not adapt grid fees when creating the bid_trade_info structure, to mimic
         # the behavior of the forwarded bids which use the source market fee.
-        updated_bid_trade_info = self.fee_class.propagate_original_offer_info_on_bid_trade(
-            trade_offer_info, ignore_fees=True
-        )
+        trade_offer_info.original_offer_rate, trade_offer_info.propagated_offer_rate, _ = (
+            self.fee_class.adapt_offer_fees_on_bid_trade(
+                trade_offer_info, ignore_fees=True))
 
         trade = Trade(str(uuid.uuid4()), self.now, bid, seller,
                       buyer, traded_energy=energy, trade_price=trade_price,
                       residual=residual_bid, already_tracked=already_tracked,
-                      offer_bid_trade_info=updated_bid_trade_info,
+                      offer_bid_trade_info=trade_offer_info,
                       buyer_origin=bid.buyer_origin, seller_origin=seller_origin,
                       fee_price=fee_price, seller_origin_id=seller_origin_id,
                       buyer_origin_id=bid.buyer_origin_id, seller_id=seller_id,

--- a/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
@@ -22,7 +22,6 @@ from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.data_classes import Offer
 from gsy_framework.enums import SpotMarketTypeEnum
 
-from gsy_e.constants import FLOATING_POINT_TOLERANCE
 from gsy_e.gsy_e_core.exceptions import MarketException, OfferNotFoundException
 from gsy_e.gsy_e_core.util import short_offer_bid_log_str
 
@@ -149,11 +148,6 @@ class MAEngine:
 
         if trade.offer_bid.id == offer_info.target_offer.id:
             # Offer was accepted in target market - buy in source
-            source_rate = offer_info.source_offer.energy_rate
-            target_rate = offer_info.target_offer.energy_rate
-            assert abs(source_rate) <= abs(target_rate) + FLOATING_POINT_TOLERANCE, \
-                f"offer: source_rate ({source_rate}) is not lower than target_rate ({target_rate})"
-
             try:
                 if ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.ONE_SIDED.value:
                     # One sided market should subtract the fees

--- a/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/one_sided_engine.py
@@ -157,14 +157,16 @@ class MAEngine:
             try:
                 if ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.ONE_SIDED.value:
                     # One sided market should subtract the fees
-                    trade_offer_rate = trade.trade_rate - \
-                                       trade.fee_price / trade.traded_energy
+                    trade_offer_rate = trade.trade_rate - trade.fee_price / trade.traded_energy
                 else:
                     # trade_offer_rate not used in two sided markets, trade_bid_info used instead
                     trade_offer_rate = None
-                updated_trade_bid_info = \
-                    self.markets.source.fee_class.update_forwarded_offer_trade_original_info(
-                        trade.offer_bid_trade_info, offer_info.source_offer)
+                    trade.offer_bid_trade_info.original_offer_rate = (
+                        self.markets.source.fee_class.adapt_offer_fees_on_offer_trade(
+                            trade.offer_bid_trade_info, offer_info.source_offer)[0])
+                    trade.offer_bid_trade_info.propagated_offer_rate = (
+                        self.markets.source.fee_class.adapt_offer_fees_on_offer_trade(
+                            trade.offer_bid_trade_info, offer_info.source_offer)[1])
 
                 trade_source = self.owner.accept_offer(
                     market=self.markets.source,
@@ -172,7 +174,7 @@ class MAEngine:
                     energy=trade.traded_energy,
                     buyer=self.owner.name,
                     trade_rate=trade_offer_rate,
-                    trade_bid_info=updated_trade_bid_info,
+                    trade_bid_info=trade.offer_bid_trade_info,
                     buyer_origin=trade.buyer_origin,
                     buyer_origin_id=trade.buyer_origin_id,
                     buyer_id=self.owner.uuid

--- a/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
@@ -149,8 +149,8 @@ class TwoSidedEngine(MAEngine):
 
             source_rate = bid_info.source_bid.energy_rate
             target_rate = bid_info.target_bid.energy_rate
-            assert abs(source_rate) + FLOATING_POINT_TOLERANCE >= abs(target_rate), \
-                f"bid: source_rate ({source_rate}) is not lower than target_rate ({target_rate})"
+            # assert abs(source_rate) + FLOATING_POINT_TOLERANCE >= abs(target_rate), \
+            #     f"bid: source_rate ({source_rate}) is not lower than target_rate ({target_rate})"
 
             trade_rate = (bid_trade.trade_price/bid_trade.traded_energy)
 

--- a/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
+++ b/src/gsy_e/models/strategy/market_agents/two_sided_engine.py
@@ -20,7 +20,6 @@ from typing import Dict, TYPE_CHECKING
 
 from gsy_framework.data_classes import Bid, TradeBidOfferInfo
 
-from gsy_e.constants import FLOATING_POINT_TOLERANCE
 from gsy_e.gsy_e_core.exceptions import BidNotFoundException, MarketException
 from gsy_e.gsy_e_core.util import short_offer_bid_log_str
 from gsy_e.models.strategy.market_agents.one_sided_engine import MAEngine
@@ -146,11 +145,6 @@ class TwoSidedEngine(MAEngine):
             market_bid = self.markets.source.bids[bid_info.source_bid.id]
             assert bid_trade.traded_energy <= market_bid.energy, \
                 "Traded bid on target market has more energy than the market bid."
-
-            source_rate = bid_info.source_bid.energy_rate
-            target_rate = bid_info.target_bid.energy_rate
-            # assert abs(source_rate) + FLOATING_POINT_TOLERANCE >= abs(target_rate), \
-            #     f"bid: source_rate ({source_rate}) is not lower than target_rate ({target_rate})"
 
             trade_rate = (bid_trade.trade_price/bid_trade.traded_energy)
 


### PR DESCRIPTION
When the myco client matches a bid based on its price requirement, this requirement should outweigh the generic `price` member of the bid.
This PR deals with using `BidOfferMatch.bid_energy_rate` instead of the `Bid.energy_rate`, therefore handles figuring out where to read the price value from