### PR TITLE
Fix log levels when receiving incorrect orders

### DIFF
--- a/src/gsy_e/models/strategy/external_strategies/__init__.py
+++ b/src/gsy_e/models/strategy/external_strategies/__init__.py
@@ -369,8 +369,14 @@ class ExternalMixin:
                 "area_uuid": self.device.uuid,
                 "market_type": market.type_name,
                 "message": response_message}
-        except (OrderCanNotBePosted, GSyException):
-            logging.exception("Error when handling offer on area %s", self.device.name)
+        except (OrderCanNotBePosted, GSyException) as ex:
+            if isinstance(ex, OrderCanNotBePosted):
+                # This can happen in the normal flow, when the user sends an incorrect offer
+                logging.info("Error when handling offer on area %s. %s", self.device.name, ex)
+            else:
+                # This is more unexpected and we might want to be notified
+                logging.exception("Error when handling offer on area %s. %s", self.device.name, ex)
+
             response = {
                 "command": "offer", "status": "error",
                 "market_type": market.type_name,
@@ -423,8 +429,14 @@ class ExternalMixin:
                 "transaction_id": arguments.get("transaction_id"),
                 "market_type": market.type_name,
                 "message": response_message}
-        except (OrderCanNotBePosted, GSyException):
-            logging.exception("Error when handling bid on area %s", self.device.name)
+        except (OrderCanNotBePosted, GSyException) as ex:
+            if isinstance(ex, OrderCanNotBePosted):
+                # This can happen in the normal flow, when the user sends an incorrect bid
+                logging.info("Error when handling bid on area %s. %s", self.device.name, ex)
+            else:
+                # This is more unexpected and we might want to be notified
+                logging.exception("Error when handling bid on area %s. %s", self.device.name, ex)
+
             response = {
                 "command": "bid", "status": "error",
                 "area_uuid": self.device.uuid,


### PR DESCRIPTION
## Reason for the proposed changes

This error is currently spamming our logs, but it is often caused by an incorrect order sent by the user. Therefore, the message is just part of the regular flow and should probably not be logged as an exception, but rather as an INFO message.

## Proposed changes

- Change log level of the `OrderCanNotBePosted` exception handling to `INFO`.