### PR TITLE
Fixed the failing test by not modifying the original bid reference, b…

### DIFF
--- a/tests/test_two_sided_market.py
+++ b/tests/test_two_sided_market.py
@@ -141,7 +141,7 @@ class TestTwoSidedMarket:
         with pytest.raises(InvalidBidOfferPairException):
             # should raise an exception as buyer_id is not in trading_partners
             market._validate_requirements_satisfied(recommendation)
-        bid.buyer_id = "bid_id2"
+        recommendation.bid.buyer_id = "bid_id2"
         market._validate_requirements_satisfied(recommendation)  # Should not raise any exceptions
         # bid.requirements.append({"energy_type": ["Grey"]})
         recommendation.matching_requirements["bid_requirement"] = {"energy_type": ["Grey"]}


### PR DESCRIPTION
…ut the copy of the original bid on the recommendation.

## Reason for the proposed changes

CI failed due to a unit test failing.

## Proposed changes

Corrected the unit test by modifying the recommendation and not the original copy of the bid. 
Most probably the root cause was gsy-framework changes, and gsy-e not adapted to the framework changes. 

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
