### PR TITLE
Ignore iSort configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,9 +103,10 @@ requirements/local.*
 gsy-e-simulation
 
 # Ink contract builds
-
 src/gsy_e/blockchain/contracts/ink/target
 
 # Cargo.lock files
-
 Cargo.lock
+
+# iSort configuration
+.isort.cfg


### PR DESCRIPTION
## Reason for the proposed changes

The iSort configuration file is used by editors to figure out how to sort import statements. The alternative to this PR would be to actually push the `isort.cfg` file directly, but I have the feeling that the other team members are not needing this.

## Proposed changes

- Ignore iSort configuration file, to allow developers to define it individually.

---

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
