### PR TITLE
WIP: GSYE-165: Renamed 'StrictRedis' to 'Redis' as it is deprecated.

### DIFF
--- a/src/gsy_e/gsy_e_core/exchange_jobs.py
+++ b/src/gsy_e/gsy_e_core/exchange_jobs.py
@@ -20,7 +20,7 @@ from os import environ, getpid
 
 from gsy_e.gsy_e_core.util import get_simulation_queue_name
 from pendulum import now
-from redis import StrictRedis
+from redis import Redis
 from rq import Connection, Worker, get_current_job
 from rq.decorators import job
 
@@ -37,8 +37,12 @@ def start(scenario, settings, events, aggregator_device_mapping, saved_state):
 
 
 def main():
-    with Connection(StrictRedis.from_url(environ.get('REDIS_URL', 'redis://localhost'),
-                                         retry_on_timeout=True)):
+    with Connection(
+        Redis.from_url(
+            environ.get('REDIS_URL', 'redis://localhost'),
+            retry_on_timeout=True
+        )
+    ):
         worker = Worker(
             [get_simulation_queue_name()],
             name=f'simulation.{getpid()}.{now().timestamp()}', log_job_description=False

--- a/src/gsy_e/gsy_e_core/launcher.py
+++ b/src/gsy_e/gsy_e_core/launcher.py
@@ -20,7 +20,7 @@ import os
 import click
 
 from datetime import datetime, timedelta
-from redis import StrictRedis
+from redis import Redis
 from rq import Queue
 from subprocess import Popen
 from time import sleep
@@ -34,7 +34,7 @@ MAX_JOBS = os.environ.get('D3A_MAX_JOBS_PER_POD', 2)
 
 class Launcher:
     def __init__(self, max_jobs=None, max_delay_seconds=2):
-        self.redis_connection = StrictRedis.from_url(REDIS_URL, retry_on_timeout=True)
+        self.redis_connection = Redis.from_url(REDIS_URL, retry_on_timeout=True)
         self.queue = Queue(get_simulation_queue_name(), connection=self.redis_connection)
         self.max_jobs = max_jobs if max_jobs is not None else int(MAX_JOBS)
         self.max_delay = timedelta(seconds=max_delay_seconds)

--- a/src/gsy_e/gsy_e_core/redis_connections/aggregator.py
+++ b/src/gsy_e/gsy_e_core/redis_connections/aggregator.py
@@ -6,14 +6,14 @@ from threading import Lock
 import gsy_e.constants
 from gsy_e.gsy_e_core.global_objects_singleton import global_objects
 from gsy_framework.utils import create_subdict_or_update
-from redis import StrictRedis
+from redis import Redis
 
 
 class AggregatorHandler:
     """
     Handles event sending, command responses to all connected aggregators
     """
-    def __init__(self, redis_db: StrictRedis):
+    def __init__(self, redis_db: Redis):
         self.redis_db = redis_db
         self.pubsub = self.redis_db.pubsub()
         self.pending_batch_commands = {}

--- a/src/gsy_e/gsy_e_core/redis_connections/area_market.py
+++ b/src/gsy_e/gsy_e_core/redis_connections/area_market.py
@@ -23,7 +23,7 @@ from typing import Dict
 from collections.abc import Callable
 
 from gsy_framework.constants_limits import ConstSettings
-from redis import StrictRedis
+from redis import Redis
 from rq import Queue
 
 import gsy_e.constants
@@ -40,7 +40,7 @@ class RedisCommunicator:
     """Base class for redis communication using pubsub."""
 
     def __init__(self):
-        self.redis_db = StrictRedis.from_url(REDIS_URL, retry_on_timeout=True)
+        self.redis_db = Redis.from_url(REDIS_URL, retry_on_timeout=True)
         self.pubsub = self.redis_db.pubsub()
         self.pubsub_response = self.redis_db.pubsub()
         self.event = Event()

--- a/src/gsy_e/gsy_e_core/redis_connections/simulation.py
+++ b/src/gsy_e/gsy_e_core/redis_connections/simulation.py
@@ -25,7 +25,7 @@ from typing import Dict, TYPE_CHECKING, Optional
 from gsy_framework.constants_limits import HeartBeat, ConstSettings
 from gsy_framework.exceptions import GSyException
 from gsy_framework.utils import RepeatingTimer
-from redis import StrictRedis
+from redis import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 from rq import get_current_job
 from rq.exceptions import NoSuchJobError
@@ -66,7 +66,7 @@ class RedisSimulationCommunication:
         }
 
         try:
-            self.redis_db = StrictRedis.from_url(REDIS_URL, retry_on_timeout=True)
+            self.redis_db = Redis.from_url(REDIS_URL, retry_on_timeout=True)
             pubsub = self.redis_db.pubsub()
             self._subscribe_to_channels(pubsub)
         except RedisConnectionError:
@@ -206,7 +206,7 @@ class RedisSimulationCommunication:
 
 def publish_job_error_output(job_id, traceback_str):
     """Publish error messages to the Redis simulation error message channel."""
-    StrictRedis.from_url(REDIS_URL).publish(
+    Redis.from_url(REDIS_URL).publish(
         ConstSettings.GeneralSettings.EXCHANGE_ERROR_CHANNEL,
         json.dumps({"job_id": job_id, "errors": traceback_str})
     )

--- a/tests/test_d3a_core/test_redis_area_market_communicator.py
+++ b/tests/test_d3a_core/test_redis_area_market_communicator.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch, Mock
 
 import pytest
-from redis import StrictRedis
+from redis import Redis
 
 from gsy_e.gsy_e_core.redis_connections.aggregator import AggregatorHandler
 from gsy_e.gsy_e_core.redis_connections.area_market import ExternalConnectionCommunicator
@@ -9,8 +9,8 @@ from gsy_e.gsy_e_core.redis_connections.area_market import ExternalConnectionCom
 
 @pytest.fixture(scope="function", autouse=True)
 def strict_redis():
-    with patch("gsy_e.gsy_e_core.redis_connections.area_market.StrictRedis",
-               spec=StrictRedis):
+    with patch("gsy_e.gsy_e_core.redis_connections.area_market.Redis",
+               spec=Redis):
 
         yield
 


### PR DESCRIPTION
## Reason for the proposed changes
As `StrictRedis` class is deprecated, we decided to use `Redis` instead.

## Proposed changes
- Renaming all `StrictRedis` occurrences to `Redis`.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
