### PR TITLE
GSYE-269: Set an empty list as a default children for new created area

### DIFF
--- a/src/gsy_e/gsy_e_core/area_serializer.py
+++ b/src/gsy_e/gsy_e_core/area_serializer.py
@@ -22,15 +22,6 @@ from gsy_framework.utils import convert_pendulum_to_str_in_dict, key_in_dict_and
 from gsy_e.models.area import Area # NOQA
 from gsy_e.models.strategy import BaseStrategy
 from gsy_e.models.area.throughput_parameters import ThroughputParameters
-# pylint: disable=unused-import
-from gsy_e.models.strategy.market_maker_strategy import MarketMakerStrategy  # NOQA
-from gsy_e.models.strategy.commercial_producer import CommercialStrategy  # NOQA
-from gsy_e.models.strategy.pv import PVStrategy  # NOQA
-from gsy_e.models.strategy.storage import StorageStrategy  # NOQA
-from gsy_e.models.strategy.load_hours import LoadHoursStrategy # NOQA
-from gsy_e.models.strategy.predefined_load import DefinedLoadStrategy # NOQA
-from gsy_e.models.strategy.predefined_pv import PVPredefinedStrategy, PVUserProfileStrategy  # NOQA
-from gsy_e.models.strategy.finite_power_plant import FinitePowerPlant # NOQA
 
 from gsy_e.models.leaves import Leaf # NOQA
 from gsy_e.models.leaves import *  # NOQA  pylint: disable=wildcard-import, unused-wildcard-import

--- a/src/gsy_e/gsy_e_core/area_serializer.py
+++ b/src/gsy_e/gsy_e_core/area_serializer.py
@@ -17,10 +17,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import json
 
+from gsy_framework.utils import convert_pendulum_to_str_in_dict, key_in_dict_and_not_none
+
 from gsy_e.models.area import Area # NOQA
 from gsy_e.models.strategy import BaseStrategy
 from gsy_e.models.area.throughput_parameters import ThroughputParameters
-
+# pylint: disable=unused-import
 from gsy_e.models.strategy.market_maker_strategy import MarketMakerStrategy  # NOQA
 from gsy_e.models.strategy.commercial_producer import CommercialStrategy  # NOQA
 from gsy_e.models.strategy.pv import PVStrategy  # NOQA
@@ -31,41 +33,46 @@ from gsy_e.models.strategy.predefined_pv import PVPredefinedStrategy, PVUserProf
 from gsy_e.models.strategy.finite_power_plant import FinitePowerPlant # NOQA
 
 from gsy_e.models.leaves import Leaf # NOQA
-from gsy_e.models.leaves import *  # NOQA
-from gsy_framework.utils import convert_pendulum_to_str_in_dict, key_in_dict_and_not_none
+from gsy_e.models.leaves import *  # NOQA  pylint: disable=wildcard-import, unused-wildcard-import
 
 
 class AreaEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if type(obj) is Area:
-            return self._encode_area(obj)
-        elif isinstance(obj, Leaf):
-            return self._encode_leaf(obj)
-        elif isinstance(obj, BaseStrategy):
-            return self._encode_subobject(obj)
+    """Json encoder for Area object."""
 
-    def _encode_area(self, area):
+    def default(self, o):
+        if type(o) is Area:  # pylint: disable=unidiomatic-typecheck
+            return self._encode_area(o)
+        if isinstance(o, Leaf):
+            return self._encode_leaf(o)
+        if isinstance(o, BaseStrategy):
+            return self._encode_subobject(o)
+        return None
+
+    @staticmethod
+    def _encode_area(area):
         result = {"name": area.name}
         if area.children:
-            result['children'] = area.children
+            result["children"] = area.children
         if area.uuid:
-            result['uuid'] = area.uuid
+            result["uuid"] = area.uuid
         if area.strategy:
-            result['strategy'] = area.strategy
+            result["strategy"] = area.strategy
         if area.display_type:
-            result['display_type'] = area.display_type
+            result["display_type"] = area.display_type
         return result
 
-    def _encode_subobject(self, obj):
+    @staticmethod
+    def _encode_subobject(obj):
         result = {"type": obj.__class__.__name__}
-        kwargs = {key: getattr(obj, key) for key in getattr(obj, 'parameters', [])
+        kwargs = {key: getattr(obj, key) for key in getattr(obj, "parameters", [])
                   if hasattr(obj, key)}
         if kwargs:
             kwargs = _convert_member_dt_to_string(kwargs)
-            result['kwargs'] = kwargs
+            result["kwargs"] = kwargs
         return result
 
-    def _encode_leaf(self, obj):
+    @staticmethod
+    def _encode_leaf(obj):
         description = {"name": obj.name,
                        "type": obj.__class__.__name__,
                        "display_type": obj.display_type}
@@ -76,10 +83,10 @@ class AreaEncoder(json.JSONEncoder):
 
 def _convert_member_dt_to_string(in_dict):
     """
-    Converts Datetime keys of members of in_dict into strings
+    Converts Datetime keys of members of in_dict into strings.
     """
     for key, value in in_dict.items():
-        if type(value) == dict:
+        if isinstance(value, dict):
             outdict = {}
             convert_pendulum_to_str_in_dict(value, outdict)
             in_dict[key] = outdict
@@ -87,24 +94,24 @@ def _convert_member_dt_to_string(in_dict):
 
 
 def area_to_string(area):
-    """Create a json string representation of an Area"""
+    """Create a json string representation of an Area."""
     return json.dumps(area, cls=AreaEncoder)
 
 
 def _instance_from_dict(description):
     try:
-        return globals()[description['type']](**description.get('kwargs', dict()))
+        return globals()[description["type"]](**description.get("kwargs", {}))
+    # pylint: disable=broad-except
     except Exception as exception:
-        if 'type' in description and type(exception) is KeyError:
-            raise ValueError("Unknown class '%s'" % description['type'])
-        else:
-            raise exception
+        if "type" in description and isinstance(exception, KeyError):
+            raise ValueError(f"Unknown class '{description['type']}'") from exception
+        raise exception
 
 
 def _leaf_from_dict(description, config):
-    leaf_type = globals().get(description.pop('type'), type(None))
+    leaf_type = globals().get(description.pop("type"), type(None))
     if not issubclass(leaf_type, Leaf):
-        raise ValueError("Unknown leaf type '%s'" % leaf_type)
+        raise ValueError(f"Unknown leaf type '{leaf_type}'")
     display_type = description.pop("display_type", None)
     leaf_object = leaf_type(**description, config=config)
     if display_type is not None:
@@ -113,25 +120,26 @@ def _leaf_from_dict(description, config):
 
 
 def area_from_dict(description, config):
+    """Return an Area object based on representation dict."""
     def optional(attr):
         return _instance_from_dict(description[attr]) if attr in description else None
     try:
-        if 'type' in description:
+        if "type" in description:
             return _leaf_from_dict(description, config)  # Area is a Leaf
-        name = description['name']
-        uuid = description.get('uuid', None)
-        external_connection_available = description.get('allow_external_connection', False)
-        baseline_peak_energy_import_kWh = description.get('baseline_peak_energy_import_kWh', None)
-        baseline_peak_energy_export_kWh = description.get('baseline_peak_energy_export_kWh', None)
-        import_capacity_kVA = description.get('import_capacity_kVA', None)
-        export_capacity_kVA = description.get('export_capacity_kVA', None)
-        if key_in_dict_and_not_none(description, 'children'):
-            children = [area_from_dict(child, config) for child in description['children']]
+        name = description["name"]
+        uuid = description.get("uuid", None)
+        external_connection_available = description.get("allow_external_connection", False)
+        baseline_peak_energy_import_kWh = description.get("baseline_peak_energy_import_kWh", None)
+        baseline_peak_energy_export_kWh = description.get("baseline_peak_energy_export_kWh", None)
+        import_capacity_kVA = description.get("import_capacity_kVA", None)
+        export_capacity_kVA = description.get("export_capacity_kVA", None)
+        if key_in_dict_and_not_none(description, "children"):
+            children = [area_from_dict(child, config) for child in description["children"]]
         else:
             children = []
-        grid_fee_percentage = description.get('grid_fee_percentage', None)
-        grid_fee_constant = description.get('grid_fee_constant', None)
-        area = Area(name, children, uuid, optional('strategy'), config,
+        grid_fee_percentage = description.get("grid_fee_percentage", None)
+        grid_fee_constant = description.get("grid_fee_constant", None)
+        area = Area(name, children, uuid, optional("strategy"), config,
                     grid_fee_percentage=grid_fee_percentage,
                     grid_fee_constant=grid_fee_constant,
                     external_connection_available=external_connection_available and
@@ -146,15 +154,16 @@ def area_from_dict(description, config):
             area.display_type = description["display_type"]
         return area
     except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
-        raise ValueError("Input is not a valid area description (%s)" % str(error)) from error
+        raise ValueError(f"Input is not a valid area description ({str(error)})") from error
 
 
 def area_from_string(string, config):
-    """Recover area from its json string representation"""
+    """Recover area from its json string representation."""
     return area_from_dict(json.loads(string), config)
 
 
-def are_all_areas_unique(area, list_of_areas=set()):
+def are_all_areas_unique(area, list_of_areas=set()):  # pylint: disable=dangerous-default-value
+    """Check if area name is unique."""
     assert area.name not in list_of_areas
     list_of_areas.add(area.name)
 

--- a/src/gsy_e/gsy_e_core/area_serializer.py
+++ b/src/gsy_e/gsy_e_core/area_serializer.py
@@ -128,7 +128,7 @@ def area_from_dict(description, config):
         if key_in_dict_and_not_none(description, 'children'):
             children = [area_from_dict(child, config) for child in description['children']]
         else:
-            children = None
+            children = []
         grid_fee_percentage = description.get('grid_fee_percentage', None)
         grid_fee_constant = description.get('grid_fee_constant', None)
         area = Area(name, children, uuid, optional('strategy'), config,

--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -110,7 +110,7 @@ class AreaBase:
         self.parent = None
         self.children = (
             AreaChildrenList(self, children)
-            if children is not None
+            if children
             else AreaChildrenList(self))
         for child in self.children:
             child.parent = self
@@ -451,7 +451,7 @@ class Area(AreaBase):
 
         if deactivate:
             return
-
+        # pylint: disable=fixme
         # TODO: Refactor and port the future, spot, settlement and balancing market creation to
         # AreaMarkets class, in order to create all necessary markets with one call.
         changed = self._markets.create_new_spot_market(now_value, AvailableMarketTypes.SPOT, self)


### PR DESCRIPTION
## Reason for the proposed changes

Sanitize the `Area`'s `children` parameter (e.g. like in `SimulationEndpointBuffer`) and set the default value always to an empty list.

## Proposed changes

Set an empty list as a default children for new created area in `area_from_dict`.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
