### PR TITLE
GSYE-53: Update settings file with every fab sync run.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -122,6 +122,7 @@ def sync():
         )
         local("pip install -e .")
     _ensure_pre_commit()
+    write_default_settings_file()
 
 
 @task


### PR DESCRIPTION
## Reason for the proposed changes
As asked by [GSYE-53](https://gridsingularity.atlassian.net/browse/GSYE-53)

## Proposed changes

- calling `write_default_settings_file` task at the end of `fab sync` task.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
