### PR TITLE
Feature/gsye 255 fix

### DIFF
--- a/src/gsy_e/models/strategy/external_strategies/load.py
+++ b/src/gsy_e/models/strategy/external_strategies/load.py
@@ -424,6 +424,9 @@ class LoadForecastExternalStrategy(ForecastExternalMixin, LoadProfileExternalStr
                  (ConstSettings.BalancingSettings.OFFER_DEMAND_RATIO,
                   ConstSettings.BalancingSettings.OFFER_SUPPLY_RATIO),
                  use_market_maker_rate: bool = False,
+                 avg_power_W=0,
+                 hrs_per_day=0,
+                 hrs_of_day=None,
                  daily_load_profile=None,
                  daily_load_profile_uuid=None):
         """

--- a/src/gsy_e/models/strategy/external_strategies/load.py
+++ b/src/gsy_e/models/strategy/external_strategies/load.py
@@ -402,7 +402,7 @@ class LoadForecastExternalEnergyParams(DefinedLoadEnergyParameters):
     methods of the DefinedLoadEnergyParameters.
     """
 
-    def _read_or_rotate_profiles(self, reconfigure=False) -> None:
+    def read_or_rotate_profiles(self, reconfigure=False) -> None:
         """Overridden with empty implementation to disable reading profile from DB."""
 
     def event_activate_energy(self, area):


### PR DESCRIPTION
## Reason for the proposed changes

Added extra parameters for the load forecast strategy. Renamed read_or_rotate_profiles for the load external forecast strategy to make it public and override the base class implementation.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
