### PR TITLE
GSYE-189-refactor: Omit returning if the update_counters were actuall…

### DIFF
--- a/src/gsy_e/models/strategy/storage.py
+++ b/src/gsy_e/models/strategy/storage.py
@@ -365,8 +365,9 @@ class StorageStrategy(BidEnabledStrategy):
             self.offer_update.update(market, self)
 
         self.bid_update.increment_update_counter_all_markets(self)
-        if self.offer_update.increment_update_counter_all_markets(self):
-            self._buy_energy_one_sided_spot_market(market)
+        self.offer_update.increment_update_counter_all_markets(self)
+
+        self._buy_energy_one_sided_spot_market(market)
 
         self._future_market_strategy.event_tick(self)
 
@@ -480,6 +481,8 @@ class StorageStrategy(BidEnabledStrategy):
 
     def _buy_energy_one_sided_spot_market(self, market, offer=None):
         if not market:
+            return
+        if ConstSettings.MASettings.MARKET_TYPE != SpotMarketTypeEnum.ONE_SIDED.value:
             return
         max_affordable_offer_rate = self.bid_update.get_updated_rate(market.time_slot)
 

--- a/src/gsy_e/models/strategy/update_frequency.py
+++ b/src/gsy_e/models/strategy/update_frequency.py
@@ -41,9 +41,8 @@ class TemplateStrategyUpdaterInterface:
     def update_and_populate_price_settings(self, area: "Area") -> None:
         """Update the price settings. Usually called during the market cycle event"""
 
-    def increment_update_counter_all_markets(self, strategy: "BaseStrategy") -> bool:
+    def increment_update_counter_all_markets(self, strategy: "BaseStrategy") -> None:
         """Increment the update counter for all markets. Usually called during the tick event"""
-        return False
 
     def set_parameters(self, *, initial_rate: float = None, final_rate: float = None,
                        energy_rate_change_per_update: float = None, fit_to_limit: bool = None,
@@ -60,11 +59,14 @@ class TemplateStrategyUpdaterInterface:
 class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
     """Manage template strategy bid / offer posting. Updates periodically the energy rate
     of the posted bids or offers. Base class"""
+
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, initial_rate: float, final_rate: float, fit_to_limit: bool = True,
                  energy_rate_change_per_update: float = None,
                  update_interval: Duration = duration(
                     minutes=ConstSettings.GeneralSettings.DEFAULT_UPDATE_INTERVAL),
                  rate_limit_object: Callable = max):
+        # pylint: disable=too-many-arguments
         self.fit_to_limit = fit_to_limit
 
         # initial input values (currently of type float)
@@ -91,6 +93,7 @@ class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
         self.rate_limit_object = rate_limit_object
 
     def serialize(self):
+        """Return dict with configuration parameters."""
         return {
             "fit_to_limit": self.fit_to_limit,
             "update_interval": self.update_interval
@@ -99,7 +102,6 @@ class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
     def _read_or_rotate_rate_profiles(self) -> None:
         """ Creates a new chunk of profiles if the current_timestamp is not in the profile buffers
         """
-        # TODO: this needs to be implemented to except profile UUIDs and DB connection
         self.initial_rate_profile_buffer = global_objects.profiles_handler.rotate_profile(
             InputProfileTypes.IDENTITY, self.initial_rate_input)
         self.final_rate_profile_buffer = global_objects.profiles_handler.rotate_profile(
@@ -222,15 +224,12 @@ class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
                 self._time_slot_duration_in_seconds / strategy.area.config.tick_length.seconds)
         return current_tick_number * strategy.area.config.tick_length.seconds
 
-    def increment_update_counter_all_markets(self, strategy: "BaseStrategy") -> bool:
+    def increment_update_counter_all_markets(self, strategy: "BaseStrategy") -> None:
         """Update method of the class. Should be called on each tick and increments the
         update counter in order to validate whether an update in the posted energy rates
         is required."""
-        should_update = [
+        for time_slot in self._get_all_time_slots(strategy.area):
             self._increment_update_counter(strategy, time_slot)
-            for time_slot in self._get_all_time_slots(strategy.area)
-        ]
-        return any(should_update)
 
     def _increment_update_counter(self, strategy: "BaseStrategy", time_slot) -> bool:
         """Increment the counter of the number of times in which prices have been updated."""

--- a/src/gsy_e/models/strategy/update_frequency.py
+++ b/src/gsy_e/models/strategy/update_frequency.py
@@ -231,12 +231,10 @@ class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
         for time_slot in self._get_all_time_slots(strategy.area):
             self.increment_update_counter(strategy, time_slot)
 
-    def increment_update_counter(self, strategy: "BaseStrategy", time_slot) -> bool:
+    def increment_update_counter(self, strategy: "BaseStrategy", time_slot) -> None:
         """Increment the counter of the number of times in which prices have been updated."""
         if self.time_for_price_update(strategy, time_slot):
             self.update_counter[time_slot] += 1
-            return True
-        return False
 
     def time_for_price_update(self, strategy: "BaseStrategy", time_slot: DateTime) -> bool:
         """Check if the prices of bids/offers should be updated."""


### PR DESCRIPTION
…y updated in TemplateStrategyUpdaterBase.increment_update_counter_all_markets

## Reason for the proposed changes

The `increment_update_counter_all_markets` method in the update_frequency module [returns a boolean value](https://github.com/gridsingularity/gsy-e/blob/de1de82aa7a3443b5981512ce49d1cbbe1ebb279/src/gsy_e/models/strategy/update_frequency.py#L225) for showing, if there were actually any offers updated. The only place were this boolean value is actually digested is in the  [StorageStrategy](https://github.com/gridsingularity/gsy-e/blob/de1de82aa7a3443b5981512ce49d1cbbe1ebb279/src/gsy_e/models/strategy/storage.py#L368). 
As this method is called a lot of times while the simulation is running by a lot of strategies, I propose to omit tracking if the orders were updated, just for reducing the calls of `StorageStrategy._buy_energy_one_sided_spot_market` that is not frequently used by users any more anyway. 

## Proposed changes

Omit returning if the update_counters were actually updated in `TemplateStrategyUpdaterBase.increment_update_counter_all_markets`

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
