### PR TITLE
GSYE-290: Update the clock of the future market in order to track the…

### DIFF
--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -542,7 +542,7 @@ class Area(AreaBase):
         self._consume_commands_from_aggregator()
         if self.children:
             self.spot_market.update_clock(self.now)
-
+            self.future_markets.update_clock(self.now)
             for market in self._markets.settlement_markets.values():
                 market.update_clock(self.now)
         for child in self.children:


### PR DESCRIPTION
… creation time of the orders and trades in the future markets exported files

## Reason for the proposed changes

This is just a PR that enables to better understand the issue. The tracking of the trades in the future markets is not complete, meaning that the creation_time column in the exported CSV files is empty for the future markets. The time_slot  column is correctly updated. 

## Proposed changes

We need to update the clock of the future markets in order to correctly export the creation time of the future orders and trades. 

The main issue of this ticket remains to be solved.

- [x] Fix export of creation time of future orders and trades
- [ ] Fix apparent dependency to the tick length in the future markets trades. 

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
