### PR TITLE
ENHANCEMENT/GSYE-183: Validate different attributes of the BidOfferMatch object 

### DIFF
--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -421,6 +421,9 @@ class TwoSidedMarket(OneSidedMarket):
             raise InvalidBidOfferPairException("Not all bids and offers exist in the market.")
         bid_energy = recommendation.bid_energy
         offer_energy = market_offer.energy
+        if selected_energy <= 0:
+            raise InvalidBidOfferPairException(
+                f"Energy traded {selected_energy} should be more than 0.")
         if selected_energy > bid_energy:
             raise InvalidBidOfferPairException(
                 f"Energy traded {selected_energy} is higher than bids energy {bid_energy}.")

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -300,11 +300,20 @@ class TwoSidedMarket(OneSidedMarket):
 
     def _get_offer_from_seller_origin_id(self, seller_origin_id):
         """Get the first offer that has the same seller_origin_id."""
+        if seller_origin_id is None:
+            # Many offers may have seller_origin_id=None; Avoid looking for them as it is
+            # inaccurate.
+            return None
+
         return next(iter(
             [offer for offer in self.offers.values()
              if offer.seller_origin_id == seller_origin_id]), None)
 
     def _get_bid_from_buyer_origin_id(self, buyer_origin_id):
+        if buyer_origin_id is None:
+            # Many bids may have buyer_origin_id=None; Avoid looking for them as it is inaccurate.
+            return None
+
         return next(iter(
             [bid for bid in self.bids.values()
              if bid.buyer_origin_id == buyer_origin_id]), None)

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -470,7 +470,7 @@ class TwoSidedMarket(OneSidedMarket):
             if bid_matching_requirement not in bid_requirements:
                 raise InvalidBidOfferPairException(
                     f"Matching requirement {bid_matching_requirement} doesn't exist in the Bid"
-                    f" object.")
+                    " object.")
 
         offer_matching_requirement = recommendation.matching_requirements.get("offer_requirement")
         if offer_matching_requirement:

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -357,7 +357,8 @@ class TwoSidedMarket(OneSidedMarket):
                 continue
             original_bid_rate = recommended_pair.bid_energy_rate + (
                     market_bid.accumulated_grid_fees / recommended_pair.bid_energy)
-            if ConstSettings.MASettings.BID_OFFER_MATCH_TYPE == BidOfferMatchAlgoEnum.PAY_AS_BID:
+            if ConstSettings.MASettings.BID_OFFER_MATCH_TYPE == \
+                    BidOfferMatchAlgoEnum.PAY_AS_BID.value:
                 trade_rate = original_bid_rate
             else:
                 trade_rate = self.fee_class.calculate_original_trade_rate_from_clearing_rate(

--- a/src/gsy_e/models/market/two_sided.py
+++ b/src/gsy_e/models/market/two_sided.py
@@ -436,7 +436,7 @@ class TwoSidedMarket(OneSidedMarket):
                 f"{recommendation.bid_energy_rate}.")
         if market_offer.energy_rate > clearing_rate + FLOATING_POINT_TOLERANCE:
             raise InvalidBidOfferPairException(
-                f"Trade rate {clearing_rate} is higher than offer energy rate "
+                f"Trade rate {clearing_rate} is lower than offer energy rate "
                 f"{market_offer.energy_rate}.")
 
         self._validate_matching_requirements(recommendation)

--- a/tests/test_two_sided_market.py
+++ b/tests/test_two_sided_market.py
@@ -648,7 +648,7 @@ class TestTwoSidedMarketMatchRecommendations:
         assert len(market.trades) == 0
 
     @staticmethod
-    def test_validate_recommendation_requirement_price(market):
+    def test_validate_recommendation_bid_requirement_price(market):
         """Test validate bid price requirement in PAY_AS_BID market."""
         ConstSettings.MASettings.BID_OFFER_MATCH_TYPE = BidOfferMatchAlgoEnum.PAY_AS_BID.value
         bid = Bid(
@@ -673,4 +673,33 @@ class TestTwoSidedMarketMatchRecommendations:
             recommended_match.serializable_dict()
         ])
         assert len(market.trades) == 1
+        assert market.accumulated_trade_price == 45
+
+    @staticmethod
+    def test_validate_recommended_bid_requirement_energy(market):
+        """Test validate bid energy requirement in PAY_AS_BID market."""
+        ConstSettings.MASettings.BID_OFFER_MATCH_TYPE = BidOfferMatchAlgoEnum.PAY_AS_BID.value
+        bid = Bid(
+            "bid_id1", pendulum.now(), price=60, energy=3, buyer="Buyer", buyer_id="buyer1",
+            time_slot="2021-10-06T12:00", requirements=[
+                {"trading_partners": ["seller1"], "energy": 2, "price": 45}])
+        offer = Offer("offer_id1", pendulum.now(), price=60, energy=3, seller="Seller",
+                      seller_id="seller1", time_slot="2021-10-06T12:00")
+
+        market.bids = {"bid_id1": bid}
+        market.offers = {"offer_id1": offer}
+
+        # valid match
+        recommended_match = BidOfferMatch(
+            bid=bid.serializable_dict(), offer=offer.serializable_dict(),
+            trade_rate=20, selected_energy=2, market_id=market.id,
+            time_slot="2021-10-06T12:00", matching_requirements={
+                "bid_requirement": {"trading_partners": ["seller1"], "energy": 2, "price": 45}
+            })
+        market.validate_bid_offer_match(recommended_match)
+        market.match_recommendations([
+            recommended_match.serializable_dict()
+        ])
+        assert len(market.trades) == 1
+        assert market.accumulated_trade_energy == 2
         assert market.accumulated_trade_price == 45

--- a/tests/test_two_sided_market.py
+++ b/tests/test_two_sided_market.py
@@ -521,8 +521,6 @@ class TestTwoSidedMarketMatchRecommendations:
                 "offer_requirement": {}
             })
 
-        market.validate_bid_offer_match(recommended_match)
-
         recommendations = [recommended_match.serializable_dict()]
         market.match_recommendations(recommendations)
         assert len(market.trades) == 1

--- a/tests/test_two_sided_market.py
+++ b/tests/test_two_sided_market.py
@@ -8,6 +8,7 @@ import pytest
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.data_classes import BidOfferMatch
 from gsy_framework.data_classes import TradeBidOfferInfo, Trade
+from gsy_framework.enums import BidOfferMatchAlgoEnum
 from gsy_framework.matching_algorithms import (
     PayAsBidMatchingAlgorithm, PayAsClearMatchingAlgorithm
 )
@@ -648,6 +649,8 @@ class TestTwoSidedMarketMatchRecommendations:
 
     @staticmethod
     def test_validate_recommendation_requirement_price(market):
+        """Test validate bid price requirement in PAY_AS_BID market."""
+        ConstSettings.MASettings.BID_OFFER_MATCH_TYPE = BidOfferMatchAlgoEnum.PAY_AS_BID.value
         bid = Bid(
             "bid_id1", pendulum.now(), price=35, energy=1, buyer="Buyer", buyer_id="buyer1",
             time_slot="2021-10-06T12:00", requirements=[


### PR DESCRIPTION
## Reason for the proposed changes

The BidOfferMatch objects provided by the myco-sdk are directly used by the gsy-e to validate and confirm the trade. Thus, it is crucial to make sure that the provided BidOfferMatch is valid and matches the corresponding offer/bid of the market.

## Proposed changes
- Fix `_get_offer_from_seller_origin_id` to avoid unwanted match in the market
- Fix `_get_bid_from_buyer_origin_id` to avoid unwanted match in the market
- Override the offer/bid object of the recommended match provided by the myco-sdk with the corresponding offer/bid object from the market to avoid myco-sdk to manipulate the market
- Validate that `selected_energy` of a recommended match to be greater than 0
- Validate Validate a matching_requirement actually exists in the Bid/Offer object of the market
- Add unit tests for checking the match recommendation validators
- Fix incorrect comparison in market.match_recommendations
- Fix a wrong error message

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
