### PR TITLE
TESTS-153: Specify gsy-framework branch on tox integrationtest testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,8 @@ passenv = {[testenv]passenv} INTEGRATION_TESTS_REPO INTEGRATION_TESTS_BRANCH
 commands_pre =
     {[testenv]commands_pre}
     pip install -e .
+    pip uninstall -y gsy-framework
+    pip install git+https://github.com/gridsingularity/gsy-framework@{env:GSY_FRAMEWORK_BRANCH:master}
     git clone \
         -b {env:INTEGRATION_TESTS_BRANCH:master} \
         {env:INTEGRATION_TESTS_REPO:git@github.com:gridsingularity/gsy-backend-integration-tests.git} \
@@ -64,8 +66,6 @@ commands_pre =
     python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
     pip install -rrequirements/pandapower.txt
     {[testenv:integrationtests]commands_pre}
-    pip uninstall -y gsy-framework
-    pip install git+https://github.com/gridsingularity/gsy-framework@{env:GSY_FRAMEWORK_BRANCH:master}
 commands =
     flake8
     {[testenv:coverage]commands}


### PR DESCRIPTION
## Reason for the proposed changes

Having the possibility to specify a particular gsy-framework branch when running integrationtests tox testenv, could be of use.


## Proposed changes

- Add extra commands_pre instructions to install the branch manually.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
