### PR TITLE
GSYE-323: Remove excessive keyword argument: `pricing_scheme`

### DIFF
--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -120,7 +120,6 @@ def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
             config.area = scenario
 
         kwargs = {"no_export": True,
-                  "pricing_scheme": 0,
                   "seed": settings.get("random_seed", 0)}
 
         gsy_e.constants.CONNECT_TO_PROFILES_DB = True


### PR DESCRIPTION
## Reason for the proposed changes

The extra `pricing_scheme` keyword argument causes `launch_simulation_from_rq_job` to fail.

## Proposed changes

- Remove `pricing_scheme` from **kwargs passed to `run_simulation`

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
