### PR TITLE
GSYE-276: Set the clock updater in the activate_future_markets

### DIFF
--- a/src/gsy_e/models/area/markets.py
+++ b/src/gsy_e/models/area/markets.py
@@ -86,6 +86,7 @@ class AreaMarkets:
                               grid_fee_const=area.grid_fee_constant),
             name=area.name)
         self.future_markets = market
+        self.future_markets.update_clock(area.now)
         area.dispatcher.create_market_agents_for_future_markets(market)
 
     def activate_market_rotators(self):


### PR DESCRIPTION
## Reason for the proposed changes

Since the Offer and Bid gets `creation_time` from the Market `now` attribute, it should be populated before the market cycle, and not only in `execute_actions_after_tick_event`.

## Proposed changes

Add `update_clock` in `activate_future_markets` to populate `now` attribute for future markets.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
