### PR TITLE
Change log level of simulation stopping to INFO

### DIFF
--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -29,7 +29,7 @@ def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
                                   events: Optional[str], aggregator_device_mapping: str,
                                   saved_state: bytes, job_id: str):
     """Launch simulation from rq job."""
-    logging.getLogger().setLevel(logging.ERROR)
+    logging.getLogger().setLevel(logging.WARNING)
     scenario = decompress_and_decode_queued_strings(scenario)
     gsy_e.constants.CONFIGURATION_ID = scenario.pop("configuration_uuid")
     if "collaboration_uuid" in scenario:
@@ -37,8 +37,9 @@ def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
         GlobalConfig.IS_CANARY_NETWORK = scenario.pop("is_canary_network", False)
         gsy_e.constants.RUN_IN_REALTIME = GlobalConfig.IS_CANARY_NETWORK
     saved_state = decompress_and_decode_queued_strings(saved_state)
-    log.error("Starting simulation with job_id: %s and configuration id: %s",
-              job_id, gsy_e.constants.CONFIGURATION_ID)
+    log.warning(
+        "Starting simulation with job_id: %s and configuration id: %s",
+        job_id, gsy_e.constants.CONFIGURATION_ID)
 
     try:
         if settings is None:
@@ -132,7 +133,7 @@ def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
                        slot_length_realtime=slot_length_realtime,
                        kwargs=kwargs)
 
-        log.info(
+        log.warning(
             "Finishing simulation with job_id: %s and configuration id: %s",
             job_id, gsy_e.constants.CONFIGURATION_ID)
 

--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -24,10 +24,10 @@ def decompress_and_decode_queued_strings(queued_string: bytes) -> Dict:
     return pickle.loads(decompress(queued_string))
 
 
+# pylint: disable-next=too-many-statements, too-many-arguments, too-many-locals
 def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
                                   events: Optional[str], aggregator_device_mapping: str,
                                   saved_state: bytes, job_id: str):
-    # pylint: disable=too-many-arguments, too-many-locals
     """Launch simulation from rq job."""
     logging.getLogger().setLevel(logging.ERROR)
     scenario = decompress_and_decode_queued_strings(scenario)
@@ -132,11 +132,11 @@ def launch_simulation_from_rq_job(scenario: bytes, settings: Optional[Dict],
                        slot_length_realtime=slot_length_realtime,
                        kwargs=kwargs)
 
-        log.error("Finishing simulation with job_id: %s and configuration id: %s",
-                  job_id, gsy_e.constants.CONFIGURATION_ID)
+        log.info(
+            "Finishing simulation with job_id: %s and configuration id: %s",
+            job_id, gsy_e.constants.CONFIGURATION_ID)
 
-    # pylint: disable=broad-except
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         # pylint: disable=import-outside-toplevel
         from gsy_e.gsy_e_core.redis_connections.simulation import publish_job_error_output
         publish_job_error_output(job_id, traceback.format_exc())

--- a/src/gsy_e/gsy_e_core/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation.py
@@ -613,8 +613,9 @@ class Simulation:
                 self._time.handle_slowdown_and_realtime(tick_no, self._setup.config)
 
                 if self._status.stopped:
-                    log.error("Received stop command for configuration id %s and job id %s.",
-                              gsy_e.constants.CONFIGURATION_ID, self._simulation_id)
+                    log.info(
+                        "Received stop command for configuration id %s and job id %s.",
+                        gsy_e.constants.CONFIGURATION_ID, self._simulation_id)
                     sleep(5)
                     self._simulation_finish_actions(slot_count)
                     return
@@ -795,8 +796,9 @@ class CoefficientSimulation(Simulation):
             self._time.handle_slowdown_and_realtime(0, self._setup.config)
 
             if self._status.stopped:
-                log.error("Received stop command for configuration id %s and job id %s.",
-                          gsy_e.constants.CONFIGURATION_ID, self._simulation_id)
+                log.info(
+                    "Received stop command for configuration id %s and job id %s.",
+                    gsy_e.constants.CONFIGURATION_ID, self._simulation_id)
                 sleep(5)
                 self._simulation_finish_actions(slot_count)
                 return

--- a/src/gsy_e/gsy_e_core/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation.py
@@ -613,7 +613,7 @@ class Simulation:
                 self._time.handle_slowdown_and_realtime(tick_no, self._setup.config)
 
                 if self._status.stopped:
-                    log.info(
+                    log.warning(
                         "Received stop command for configuration id %s and job id %s.",
                         gsy_e.constants.CONFIGURATION_ID, self._simulation_id)
                     sleep(5)
@@ -796,7 +796,7 @@ class CoefficientSimulation(Simulation):
             self._time.handle_slowdown_and_realtime(0, self._setup.config)
 
             if self._status.stopped:
-                log.info(
+                log.warning(
                     "Received stop command for configuration id %s and job id %s.",
                     gsy_e.constants.CONFIGURATION_ID, self._simulation_id)
                 sleep(5)


### PR DESCRIPTION
## Reason for the proposed changes

We're seeing logs for stopped canary networks as errors, while they can be due to admin's choice.

## Proposed changes

- Change the log level for simulations being stopped to `INFO`.

---

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
