### PR TITLE
GSYE-256: Fixed the grid fees reduction calculation to reflect a redu…

### DIFF
--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -261,7 +261,6 @@ class CoefficientArea(AreaBase):
                  market_maker_rate: float = (
                          ConstSettings.GeneralSettings.DEFAULT_MARKET_MAKER_RATE / 100.),
                  feed_in_tariff: float = GlobalConfig.FEED_IN_TARIFF / 100.,
-                 trade_rate: float = 0.0
                  ):
         # pylint: disable=too-many-arguments
         super().__init__(name, children, uuid, strategy, config, grid_fee_percentage,
@@ -269,7 +268,6 @@ class CoefficientArea(AreaBase):
         self._coefficient_percent = coefficient_percent
         self._market_maker_rate = market_maker_rate
         self._feed_in_tariff = feed_in_tariff
-        self._trade_rate = trade_rate
         self.past_market_time_slot = None
 
     def activate_energy_parameters(self, current_time_slot: DateTime) -> None:

--- a/src/gsy_e/models/area/scm_manager.py
+++ b/src/gsy_e/models/area/scm_manager.py
@@ -196,7 +196,7 @@ class SCMManager:
         feed_in_tariff = home_data.feed_in_tariff
 
         market_maker_rate_decreased_fees = (
-                market_maker_rate + grid_fees * self._grid_fees_reduction)
+                market_maker_rate + grid_fees * (1.0 - self._grid_fees_reduction))
         market_maker_rate_normal_fees = market_maker_rate + grid_fees
 
         base_energy_bill = (

--- a/src/gsy_e/setup/gsy_e_settings.json
+++ b/src/gsy_e/setup/gsy_e_settings.json
@@ -4,7 +4,7 @@
     "slot_length": "15m",
     "tick_length": "15s",
     "cloud_coverage": 0,
-    "start_date": "2022-06-17"
+    "start_date": "2022-06-23"
   },
   "advanced_settings": {
     "GeneralSettings": {
@@ -239,6 +239,9 @@
       "OFFER_DEMAND_RATIO": 0.1,
       "OFFER_SUPPLY_RATIO": 0.1,
       "FLEXIBLE_LOADS_SUPPORT": true
+    },
+    "SCMSettings": {
+      "GRID_FEES_REDUCTION": 0.28
     }
   }
 }


### PR DESCRIPTION
…ction and not a percentage of the original grid fees.

## Reason for the proposed changes

In addition to fixing the grid fees reduction operation, also the needless trade_rate parameter was removed from the CoefficientArea class constructor.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
