### PR TITLE
GSYE-334: Delete the spot market state from the future market strategy

### DIFF
--- a/src/gsy_e/models/strategy/future/strategy.py
+++ b/src/gsy_e/models/strategy/future/strategy.py
@@ -113,6 +113,9 @@ class FutureMarketStrategyInterface:
     def update_and_populate_price_settings(self, strategy: "BaseStrategy") -> None:
         """Base class method for updating/populating price settings"""
 
+    def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
+        """Base class method for deleting the state of past or spot markets."""
+
 
 def future_strategy_bid_updater_factory(
         initial_buying_rate: float, final_buying_rate: float, asset_type: AssetType
@@ -274,6 +277,17 @@ class FutureMarketStrategy(FutureMarketStrategyInterface):
 
         self._bid_updater.increment_update_counter_all_markets(strategy)
         self._offer_updater.increment_update_counter_all_markets(strategy)
+
+    def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
+        def _delete_past_state_values(updater, market_slot):
+            updater.initial_rate.pop(market_slot, None)
+            updater.final_rate.pop(market_slot, None)
+            updater.energy_rate_change_per_update.pop(market_slot, None)
+            updater.update_counter.pop(market_slot, None)
+            updater.market_slot_added_time_mapping.pop(market_slot, None)
+
+        _delete_past_state_values(self._bid_updater, current_market_time_slot)
+        _delete_past_state_values(self._offer_updater, current_market_time_slot)
 
 
 def future_market_strategy_factory(asset_type: AssetType) -> FutureMarketStrategyInterface:

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -340,6 +340,8 @@ class LoadHoursStrategy(BidEnabledStrategy):
 
         self.state.delete_past_state_values(self.area.current_market.time_slot)
         self.bid_update.delete_past_state_values(self.area.current_market.time_slot)
+        self._future_market_strategy.delete_past_state_values(
+            self.area.current_market.time_slot)
 
     def _area_reconfigure_prices(self, **kwargs):
         if kwargs.get("initial_buying_rate") is not None:

--- a/src/gsy_e/models/strategy/pv.py
+++ b/src/gsy_e/models/strategy/pv.py
@@ -321,6 +321,8 @@ class PVStrategy(BidEnabledStrategy):
 
         self.state.delete_past_state_values(self.area.current_market.time_slot)
         self.offer_update.delete_past_state_values(self.area.current_market.time_slot)
+        self._future_market_strategy.delete_past_state_values(
+            self.area.current_market.time_slot)
 
     def event_market_cycle_price(self):
         """Manage price parameters during the market cycle event."""

--- a/src/gsy_e/models/strategy/smart_meter.py
+++ b/src/gsy_e/models/strategy/smart_meter.py
@@ -506,6 +506,9 @@ class SmartMeterStrategy(BidEnabledStrategy):
         self.bid_update.delete_past_state_values(self.area.current_market.time_slot)
         # Delete offer rates for previous market slots
         self.offer_update.delete_past_state_values(self.area.current_market.time_slot)
+        # Delete the state of the current slot from the future market cache
+        self._future_market_strategy.delete_past_state_values(
+            self.area.current_market.time_slot)
 
     def _replace_rates_with_market_maker_rates(self):
         # Reconfigure the final buying rate (for energy consumption)

--- a/src/gsy_e/models/strategy/storage.py
+++ b/src/gsy_e/models/strategy/storage.py
@@ -543,6 +543,10 @@ class StorageStrategy(BidEnabledStrategy):
         self.bid_update.delete_past_state_values(self.area.current_market.time_slot)
         self.state.delete_past_state_values(self.area.current_market.time_slot)
 
+        # Delete the state of the current slot from the future market cache
+        self._future_market_strategy.delete_past_state_values(
+            self.area.current_market.time_slot)
+
     @property
     def asset_type(self):
         return AssetType.PROSUMER


### PR DESCRIPTION
## Reason for the proposed changes
The future market strategies's state isn't cleared for markets that become spots (they are no longer future markets).

## Proposed changes
Add a call to the delete_past_state method in the future strategies that clears both bid and offer rate updaters' states.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
