### PR TITLE
GSYE-324: Add unittest for launch_simulation_from_rq_job

### DIFF
--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -16,7 +16,8 @@ from gsy_e.gsy_e_core.simulation import run_simulation
 from gsy_e.gsy_e_core.util import available_simulation_scenarios, update_advanced_settings
 from gsy_e.models.config import SimulationConfig
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def decompress_and_decode_queued_strings(queued_string: bytes) -> Dict:

--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -17,7 +17,6 @@ from gsy_e.gsy_e_core.util import available_simulation_scenarios, update_advance
 from gsy_e.models.config import SimulationConfig
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 
 def decompress_and_decode_queued_strings(queued_string: bytes) -> Dict:

--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -1,6 +1,9 @@
+# pylint: disable=broad-except
+
 import pickle
 import zlib
 
+import pytest
 from pendulum import duration
 
 from gsy_e.gsy_e_core.rq_job_handler import launch_simulation_from_rq_job
@@ -11,16 +14,19 @@ class TestRQJobUtils:
     @staticmethod
     def test_launch_simulation_from_rq_job():
         """Assure the launch_simulation_from_rq_job can successfully launch a simulation."""
-        launch_simulation_from_rq_job(
-            scenario=zlib.compress(pickle.dumps("default_2a")),
-            settings={
-                "sim_duration": duration(days=1),
-                "slot_length": duration(hours=1),
-                "tick_length": duration(minutes=6)
-            },
-            events=None,
-            aggregator_device_mapping="null",
-            saved_state=zlib.compress(pickle.dumps(None)),
-            job_id="TEST_SIM_RUNS",
-            connect_to_profiles_db=False
-        )
+        try:
+            launch_simulation_from_rq_job(
+                scenario=zlib.compress(pickle.dumps("default_2a")),
+                settings={
+                    "duration": duration(days=1),
+                    "slot_length": duration(hours=1),
+                    "tick_length": duration(minutes=6)
+                },
+                events=None,
+                aggregator_device_mapping="null",
+                saved_state=zlib.compress(pickle.dumps(None)),
+                job_id="TEST_SIM_RUNS",
+                connect_to_profiles_db=False
+            )
+        except Exception as exc: # noqa
+            pytest.fail(exc)

--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -2,6 +2,7 @@
 
 import pickle
 import zlib
+from multiprocessing import Process, Queue
 
 import pytest
 from pendulum import duration
@@ -11,22 +12,39 @@ from gsy_e.gsy_e_core.rq_job_handler import launch_simulation_from_rq_job
 
 class TestRQJobUtils:
     """Test RQ-related utilities."""
+
     @staticmethod
     def test_launch_simulation_from_rq_job():
-        """Assure the launch_simulation_from_rq_job can successfully launch a simulation."""
-        try:
-            launch_simulation_from_rq_job(
-                scenario=zlib.compress(pickle.dumps("default_2a")),
-                settings={
-                    "duration": duration(days=1),
-                    "slot_length": duration(hours=1),
-                    "tick_length": duration(minutes=6)
-                },
-                events=None,
-                aggregator_device_mapping="null",
-                saved_state=zlib.compress(pickle.dumps(None)),
-                job_id="TEST_SIM_RUNS",
-                connect_to_profiles_db=False
-            )
-        except Exception as exc: # noqa
-            pytest.fail(exc)
+        """Assure the launch_simulation_from_rq_job can successfully launch a simulation.
+        The launch_simulation_from_rq_job is ran in another process to ensure that its changes on
+        constant settings will not cause other tests to fail.
+        """
+
+        def fn(queue, **kwargs):
+            """Launch simulation and push the exception in the result queue if any.
+            This function is supposed to run in a separate process.
+            """
+            try:
+                launch_simulation_from_rq_job(**kwargs)
+            except Exception as exc:  # noqa
+                queue.put(exc)
+                raise exc
+
+        results_queue = Queue()
+        process = Process(target=fn, args=(results_queue,), kwargs={
+            "scenario": zlib.compress(pickle.dumps("default_2a")),
+            "settings": {
+                           "duration": duration(days=1),
+                           "slot_length": duration(hours=1),
+                           "tick_length": duration(minutes=6)
+                       },
+            "events": None,
+            "aggregator_device_mapping": "null",
+            "saved_state": zlib.compress(pickle.dumps(None)),
+            "job_id": "TEST_SIM_RUNS",
+            "connect_to_profiles_db": False
+        })
+        process.start()
+        process.join()
+        if process.exitcode != 0:
+            pytest.fail(results_queue.get())

--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -1,0 +1,20 @@
+import pickle
+import zlib
+
+from gsy_e.gsy_e_core.rq_job_handler import launch_simulation_from_rq_job
+
+
+class TestRQJobUtils:
+    """Test RQ-related utilities."""
+    @staticmethod
+    def test_launch_simulation_from_rq_job():
+        """Assure the launch_simulation_from_rq_job can successfully launch a simulation."""
+        launch_simulation_from_rq_job(
+            scenario=zlib.compress(pickle.dumps("default_2a")),
+            settings=None,
+            events=None,
+            aggregator_device_mapping="null",
+            saved_state=zlib.compress(pickle.dumps(None)),
+            job_id="TEST_SIM_RUNS",
+            connect_to_profiles_db=False
+        )

--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -1,6 +1,8 @@
 import pickle
 import zlib
 
+from pendulum import duration
+
 from gsy_e.gsy_e_core.rq_job_handler import launch_simulation_from_rq_job
 
 
@@ -11,7 +13,11 @@ class TestRQJobUtils:
         """Assure the launch_simulation_from_rq_job can successfully launch a simulation."""
         launch_simulation_from_rq_job(
             scenario=zlib.compress(pickle.dumps("default_2a")),
-            settings=None,
+            settings={
+                "sim_duration": duration(days=1),
+                "slot_length": duration(hours=1),
+                "tick_length": duration(minutes=6)
+            },
             events=None,
             aggregator_device_mapping="null",
             saved_state=zlib.compress(pickle.dumps(None)),

--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -34,10 +34,10 @@ class TestRQJobUtils:
         process = Process(target=fn, args=(results_queue,), kwargs={
             "scenario": zlib.compress(pickle.dumps("default_2a")),
             "settings": {
-                           "duration": duration(days=1),
-                           "slot_length": duration(hours=1),
-                           "tick_length": duration(minutes=6)
-                       },
+               "duration": duration(days=1),
+               "slot_length": duration(hours=1),
+               "tick_length": duration(minutes=6)
+            },
             "events": None,
             "aggregator_device_mapping": "null",
             "saved_state": zlib.compress(pickle.dumps(None)),


### PR DESCRIPTION
## Reason for the proposed changes

As `launch_simulation_from_rq_job` is the only entrypoint to running a simulation from the rq. It seems fair to have a test for this function ([GSYE-324](https://gridsingularity.atlassian.net/browse/GSYE-324)).

## Proposed changes

- Add `TestRQJobUtils` class
- Minor refactor to `launch_simulation_from_rq_job`

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
