### PR TITLE
GSYE-334: Fix the delete_past_state_values of the future market strategies

### DIFF
--- a/src/gsy_e/models/strategy/future/strategy.py
+++ b/src/gsy_e/models/strategy/future/strategy.py
@@ -63,11 +63,7 @@ class FutureTemplateStrategyBidUpdater(TemplateStrategyBidUpdater):
 
     def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
         """Delete irrelevant values from buffers for unneeded markets."""
-        self.initial_rate.pop(current_market_time_slot, None)
-        self.final_rate.pop(current_market_time_slot, None)
-        self.energy_rate_change_per_update.pop(current_market_time_slot, None)
-        self.update_counter.pop(current_market_time_slot, None)
-        self.market_slot_added_time_mapping.pop(current_market_time_slot, None)
+        self._delete_market_slot_data(current_market_time_slot)
 
 
 class FutureTemplateStrategyOfferUpdater(TemplateStrategyOfferUpdater):
@@ -106,11 +102,7 @@ class FutureTemplateStrategyOfferUpdater(TemplateStrategyOfferUpdater):
 
     def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
         """Delete irrelevant values from buffers for unneeded markets."""
-        self.initial_rate.pop(current_market_time_slot, None)
-        self.final_rate.pop(current_market_time_slot, None)
-        self.energy_rate_change_per_update.pop(current_market_time_slot, None)
-        self.update_counter.pop(current_market_time_slot, None)
-        self.market_slot_added_time_mapping.pop(current_market_time_slot, None)
+        self._delete_market_slot_data(current_market_time_slot)
 
 
 class FutureMarketStrategyInterface:

--- a/src/gsy_e/models/strategy/future/strategy.py
+++ b/src/gsy_e/models/strategy/future/strategy.py
@@ -285,9 +285,10 @@ class FutureMarketStrategy(FutureMarketStrategyInterface):
             updater.energy_rate_change_per_update.pop(market_slot, None)
             updater.update_counter.pop(market_slot, None)
             updater.market_slot_added_time_mapping.pop(market_slot, None)
-
-        _delete_past_state_values(self._bid_updater, current_market_time_slot)
-        _delete_past_state_values(self._offer_updater, current_market_time_slot)
+        if not isinstance(self._bid_updater, TemplateStrategyUpdaterInterface):
+            _delete_past_state_values(self._bid_updater, current_market_time_slot)
+        if not isinstance(self._offer_updater, TemplateStrategyUpdaterInterface):
+            _delete_past_state_values(self._offer_updater, current_market_time_slot)
 
 
 def future_market_strategy_factory(asset_type: AssetType) -> FutureMarketStrategyInterface:

--- a/src/gsy_e/models/strategy/future/strategy.py
+++ b/src/gsy_e/models/strategy/future/strategy.py
@@ -61,6 +61,14 @@ class FutureTemplateStrategyBidUpdater(TemplateStrategyBidUpdater):
                 if strategy.are_bids_posted(market.id, time_slot):
                     strategy.update_bid_rates(market, self.get_updated_rate(time_slot), time_slot)
 
+    def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
+        """Delete irrelevant values from buffers for unneeded markets."""
+        self.initial_rate.pop(current_market_time_slot, None)
+        self.final_rate.pop(current_market_time_slot, None)
+        self.energy_rate_change_per_update.pop(current_market_time_slot, None)
+        self.update_counter.pop(current_market_time_slot, None)
+        self.market_slot_added_time_mapping.pop(current_market_time_slot, None)
+
 
 class FutureTemplateStrategyOfferUpdater(TemplateStrategyOfferUpdater):
     """Version of TemplateStrategyOfferUpdater class for future markets"""
@@ -95,6 +103,14 @@ class FutureTemplateStrategyOfferUpdater(TemplateStrategyOfferUpdater):
                 if strategy.are_offers_posted(market.id):
                     strategy.update_offer_rates(
                         market, self.get_updated_rate(time_slot), time_slot)
+
+    def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
+        """Delete irrelevant values from buffers for unneeded markets."""
+        self.initial_rate.pop(current_market_time_slot, None)
+        self.final_rate.pop(current_market_time_slot, None)
+        self.energy_rate_change_per_update.pop(current_market_time_slot, None)
+        self.update_counter.pop(current_market_time_slot, None)
+        self.market_slot_added_time_mapping.pop(current_market_time_slot, None)
 
 
 class FutureMarketStrategyInterface:
@@ -279,16 +295,8 @@ class FutureMarketStrategy(FutureMarketStrategyInterface):
         self._offer_updater.increment_update_counter_all_markets(strategy)
 
     def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
-        def _delete_past_state_values(updater, market_slot):
-            updater.initial_rate.pop(market_slot, None)
-            updater.final_rate.pop(market_slot, None)
-            updater.energy_rate_change_per_update.pop(market_slot, None)
-            updater.update_counter.pop(market_slot, None)
-            updater.market_slot_added_time_mapping.pop(market_slot, None)
-        if not isinstance(self._bid_updater, TemplateStrategyUpdaterInterface):
-            _delete_past_state_values(self._bid_updater, current_market_time_slot)
-        if not isinstance(self._offer_updater, TemplateStrategyUpdaterInterface):
-            _delete_past_state_values(self._offer_updater, current_market_time_slot)
+        self._bid_updater.delete_past_state_values(current_market_time_slot)
+        self._offer_updater.delete_past_state_values(current_market_time_slot)
 
 
 def future_market_strategy_factory(asset_type: AssetType) -> FutureMarketStrategyInterface:

--- a/src/gsy_e/models/strategy/update_frequency.py
+++ b/src/gsy_e/models/strategy/update_frequency.py
@@ -55,6 +55,9 @@ class TemplateStrategyUpdaterInterface:
     def update(self, market: "OneSidedMarket", strategy: "BaseStrategy") -> None:
         """Update the price of existing orders to reflect the new rates."""
 
+    def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
+        """Delete irrelevant values from buffers for unneeded markets."""
+
 
 class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
     """Manage template strategy bid / offer posting. Updates periodically the energy rate

--- a/src/gsy_e/models/strategy/update_frequency.py
+++ b/src/gsy_e/models/strategy/update_frequency.py
@@ -120,6 +120,13 @@ class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
                     InputProfileTypes.IDENTITY, self.energy_rate_change_per_update_input)
             )
 
+    def _delete_market_slot_data(self, market_time_slot: DateTime) -> None:
+        self.initial_rate.pop(market_time_slot, None)
+        self.final_rate.pop(market_time_slot, None)
+        self.energy_rate_change_per_update.pop(market_time_slot, None)
+        self.update_counter.pop(market_time_slot, None)
+        self.market_slot_added_time_mapping.pop(market_time_slot, None)
+
     def delete_past_state_values(self, current_market_time_slot: DateTime) -> None:
         """Delete values from buffers before the current_market_time_slot"""
         to_delete = []
@@ -127,11 +134,7 @@ class TemplateStrategyUpdaterBase(TemplateStrategyUpdaterInterface):
             if is_time_slot_in_past_markets(market_slot, current_market_time_slot):
                 to_delete.append(market_slot)
         for market_slot in to_delete:
-            self.initial_rate.pop(market_slot, None)
-            self.final_rate.pop(market_slot, None)
-            self.energy_rate_change_per_update.pop(market_slot, None)
-            self.update_counter.pop(market_slot, None)
-            self.market_slot_added_time_mapping.pop(market_slot, None)
+            self._delete_market_slot_data(market_slot)
 
     @staticmethod
     def get_all_markets(area: "Area") -> List["OneSidedMarket"]:


### PR DESCRIPTION
## Reason for the proposed changes
The bug is raised when we instantiate the future updater as TemplateStrategyUpdaterInterface because it doesn't have all the attributes of the TemplateStrategyUpdaterBase

Another solution to this problem would be to add these missing attributes to the interface, if you favor it let me know. 

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
