### PR TITLE
Feature/gsye 294 Add Intraday market

### DIFF
--- a/src/gsy_e/gsy_e_core/enums.py
+++ b/src/gsy_e/gsy_e_core/enums.py
@@ -14,6 +14,7 @@ class AvailableMarketTypes(Enum):
     WEEK_FORWARD = 5
     MONTH_FORWARD = 6
     YEAR_FORWARD = 7
+    INTRADAY = 8
 
 
 PAST_MARKET_TYPE_FILE_SUFFIX_MAPPING = {
@@ -25,4 +26,5 @@ PAST_MARKET_TYPE_FILE_SUFFIX_MAPPING = {
     AvailableMarketTypes.WEEK_FORWARD: "-week-ahead",
     AvailableMarketTypes.MONTH_FORWARD: "-month-ahead",
     AvailableMarketTypes.YEAR_FORWARD: "-year-ahead",
+    AvailableMarketTypes.INTRADAY: "-intraday"
 }

--- a/src/gsy_e/gsy_e_core/market_counters.py
+++ b/src/gsy_e/gsy_e_core/market_counters.py
@@ -65,6 +65,15 @@ class ExternalTickCounter:
         return current_tick_in_slot % self._dispatch_tick_frequency == 0
 
 
+class IntradayMarketCounter(MarketCounter):
+    """Handle timing of intraday market clearing"""
+
+    def __init__(self):
+        super().__init__(
+            clearing_interval_min=ConstSettings.ForwardMarketSettings.
+            INTRADAY_CLEARING_INTERVAL_MINUTES)
+
+
 class HourForwardMarketCounter(MarketCounter):
     """Handle timing of hour-forward market clearing"""
 

--- a/src/gsy_e/gsy_e_core/market_counters.py
+++ b/src/gsy_e/gsy_e_core/market_counters.py
@@ -71,6 +71,15 @@ class ForwardMarketCounter:
         """Return True if it is time for market clearing"""
 
 
+class IntraDayMarketCounter(ForwardMarketCounter):
+    """Market counter for intra-day markets."""
+
+    @staticmethod
+    def is_time_for_clearing(current_time: DateTime) -> bool:
+        """Always return True because intra-day markets clear continuously."""
+        return True
+
+
 class DayForwardMarketCounter(ForwardMarketCounter):
     """Market counter for day-forward markets."""
 

--- a/src/gsy_e/models/area/event_dispatcher.py
+++ b/src/gsy_e/models/area/event_dispatcher.py
@@ -249,7 +249,8 @@ class AreaDispatcher:
                            AvailableMarketTypes.HOUR_FORWARD,
                            AvailableMarketTypes.WEEK_FORWARD,
                            AvailableMarketTypes.MONTH_FORWARD,
-                           AvailableMarketTypes.YEAR_FORWARD]:
+                           AvailableMarketTypes.YEAR_FORWARD,
+                           AvailableMarketTypes.INTRADAY]:
             return FutureAgent(**agent_constructor_arguments)
 
         assert False, f"Market type not supported {market_type}"

--- a/src/gsy_e/models/area/market_rotators.py
+++ b/src/gsy_e/models/area/market_rotators.py
@@ -71,6 +71,18 @@ class ForwardMarketRotatorBase:
                     current_time))
 
 
+class IntradayMarketRotator(ForwardMarketRotatorBase):
+    """Handles market rotation for the intraday market block"""
+
+    @staticmethod
+    def _get_last_slot_to_be_deleted(current_time: DateTime) -> DateTime:
+        return current_time.add(minutes=15)
+
+    @staticmethod
+    def _is_it_time_to_rotate(current_time: DateTime) -> bool:
+        return current_time.minute % 15 == 0
+
+
 class HourForwardMarketRotator(ForwardMarketRotatorBase):
     """Handles market rotation for the hour forward market block"""
 

--- a/src/gsy_e/models/area/markets.py
+++ b/src/gsy_e/models/area/markets.py
@@ -27,7 +27,7 @@ from gsy_e.models.area.market_rotators import (BaseRotator, DefaultMarketRotator
                                                SettlementMarketRotator, FutureMarketRotator,
                                                ForwardMarketRotatorBase, HourForwardMarketRotator,
                                                WeekForwardMarketRotator, MonthForwardMarketRotator,
-                                               YearForwardMarketRotator)
+                                               YearForwardMarketRotator, IntradayMarketRotator)
 from gsy_e.models.market import GridFee, MarketBase
 from gsy_e.models.market.balancing import BalancingMarket
 from gsy_e.models.market.future import FutureMarkets
@@ -36,7 +36,8 @@ from gsy_e.models.market.one_sided import OneSidedMarket
 from gsy_e.models.market.settlement import SettlementMarket
 from gsy_e.models.market.two_sided import TwoSidedMarket
 from gsy_e.models.market.forward import (
-    ForwardMarketBase, HourForwardMarket, WeekForwardMarket, MonthForwardMarket, YearForwardMarket)
+    ForwardMarketBase, HourForwardMarket, WeekForwardMarket, MonthForwardMarket, YearForwardMarket,
+    IntradayMarket)
 
 if TYPE_CHECKING:
     from gsy_e.models.area import Area
@@ -45,14 +46,16 @@ _FORWARD_MARKET_TYPE_MAPPING = {
     AvailableMarketTypes.HOUR_FORWARD: HourForwardMarket,
     AvailableMarketTypes.WEEK_FORWARD: WeekForwardMarket,
     AvailableMarketTypes.MONTH_FORWARD: MonthForwardMarket,
-    AvailableMarketTypes.YEAR_FORWARD: YearForwardMarket
+    AvailableMarketTypes.YEAR_FORWARD: YearForwardMarket,
+    AvailableMarketTypes.INTRADAY: IntradayMarket
 }
 
 _FORWARD_MARKET_ROTATOR_MAPPING = {
     AvailableMarketTypes.HOUR_FORWARD: HourForwardMarketRotator,
     AvailableMarketTypes.WEEK_FORWARD: WeekForwardMarketRotator,
     AvailableMarketTypes.MONTH_FORWARD: MonthForwardMarketRotator,
-    AvailableMarketTypes.YEAR_FORWARD: YearForwardMarketRotator
+    AvailableMarketTypes.YEAR_FORWARD: YearForwardMarketRotator,
+    AvailableMarketTypes.INTRADAY: IntradayMarketRotator
 }
 
 

--- a/src/gsy_e/models/market/forward.py
+++ b/src/gsy_e/models/market/forward.py
@@ -68,6 +68,22 @@ class ForwardMarketBase(FutureMarkets):
                                     self._get_end_time(current_market_time_slot), config)
 
 
+class IntradayMarket(ForwardMarketBase):
+    """Intraday market block implementation"""
+
+    @staticmethod
+    def _get_start_time(current_time: DateTime) -> DateTime:
+        return current_time.add(minutes=15)
+
+    @staticmethod
+    def _get_end_time(current_time: DateTime) -> DateTime:
+        return current_time.add(days=1)
+
+    @staticmethod
+    def _get_market_slot_duration() -> duration:
+        return duration(minutes=15)
+
+
 class HourForwardMarket(ForwardMarketBase):
     """Hour forward market implementation"""
 

--- a/src/gsy_e/models/myco_matcher/myco_internal_matcher.py
+++ b/src/gsy_e/models/myco_matcher/myco_internal_matcher.py
@@ -26,7 +26,8 @@ from gsy_e.gsy_e_core.global_objects_singleton import global_objects
 from gsy_e.models.myco_matcher.myco_matcher_interface import MycoMatcherInterface
 from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 from gsy_e.gsy_e_core.market_counters import (DayForwardMarketCounter, WeekForwardMarketCounter,
-                                              MonthForwardMarketCounter, YearForwardMarketCounter)
+                                              MonthForwardMarketCounter, YearForwardMarketCounter,
+                                              IntraDayMarketCounter)
 
 
 class MycoInternalMatcher(MycoMatcherInterface):
@@ -35,14 +36,15 @@ class MycoInternalMatcher(MycoMatcherInterface):
     def __init__(self):
         super().__init__()
         self.match_algorithm = None
-        # TBD: Which matching algorithm is applied for which forward market type
         self._forward_match_algorithms = {
+            AvailableMarketTypes.INTRADAY: PayAsBidMatchingAlgorithm,
             AvailableMarketTypes.DAY_FORWARD: PayAsClearMatchingAlgorithm,
             AvailableMarketTypes.WEEK_FORWARD: PayAsClearMatchingAlgorithm,
             AvailableMarketTypes.MONTH_FORWARD: PayAsClearMatchingAlgorithm,
             AvailableMarketTypes.YEAR_FORWARD: PayAsClearMatchingAlgorithm,
         }
         self._forward_market_counters = {
+            AvailableMarketTypes.INTRADAY: IntraDayMarketCounter,
             AvailableMarketTypes.DAY_FORWARD: DayForwardMarketCounter,
             AvailableMarketTypes.WEEK_FORWARD: WeekForwardMarketCounter,
             AvailableMarketTypes.MONTH_FORWARD: MonthForwardMarketCounter,

--- a/tests/market/test_forward.py
+++ b/tests/market/test_forward.py
@@ -22,15 +22,15 @@ from gsy_framework.data_classes import Bid, Offer, Trade
 from pendulum import datetime
 
 from gsy_e.models.area import Area
-from gsy_e.models.area.market_rotators import (HourForwardMarketRotator,
+from gsy_e.models.area.market_rotators import (HourForwardMarketRotator, IntradayMarketRotator,
                                                WeekForwardMarketRotator, MonthForwardMarketRotator,
                                                YearForwardMarketRotator)
 from gsy_e.models.market import GridFee
-from gsy_e.models.market.forward import (ForwardMarketBase, HourForwardMarket,
+from gsy_e.models.market.forward import (ForwardMarketBase, HourForwardMarket, IntradayMarket,
                                          WeekForwardMarket, MonthForwardMarket, YearForwardMarket)
 from tests.market.test_future import count_orders_in_buffers
 
-CURRENT_MARKET_SLOT = datetime(2022, 6, 19, 0, 15)
+CURRENT_MARKET_SLOT = datetime(2022, 6, 19, 0, 10)
 
 
 class TestForwardMarkets:
@@ -53,7 +53,8 @@ class TestForwardMarkets:
         return forward_markets
 
     @pytest.mark.parametrize("market_class, expected_market_count",
-                             [[HourForwardMarket, 24 * 7],
+                             [[IntradayMarket, 24 * 4],
+                              [HourForwardMarket, 24 * 7],
                               [WeekForwardMarket, 52],
                               [MonthForwardMarket, 24],
                               [YearForwardMarket, 5]])
@@ -83,7 +84,9 @@ class TestForwardMarkets:
                            for time_slot in buffer)
 
     @pytest.mark.parametrize("market_class, rotator_class, expected_market_count, rotation_time",
-                             [[HourForwardMarket, HourForwardMarketRotator, 24 * 7,
+                             [[IntradayMarket, IntradayMarketRotator, 24 * 4,
+                               CURRENT_MARKET_SLOT.set(minute=15)],
+                              [HourForwardMarket, HourForwardMarketRotator, 24 * 7,
                                CURRENT_MARKET_SLOT.set(minute=0)],
                               [WeekForwardMarket, WeekForwardMarketRotator, 52,
                                datetime(2022, 6, 20, 0, 0)],


### PR DESCRIPTION
## Reason for the proposed changes

An intraday market block is added that is a pre-configured FutureMarkets block

## Proposed changes

- Add INTRADAY market type, rotator and matcher

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
