### PR TITLE
Bug/GSYE-343: Move helper function `fn` to a non-local scope

### DIFF
--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -15,7 +15,7 @@ class TestRQJobUtils:
 
     @staticmethod
     def fn(queue, **kwargs):
-        # This helper function should be defined in a global scope, so Python can dump it when
+        # This helper function should not be defined in a local scope, so Python can dump it when
         # starting the process.
         """Launch simulation and push the exception in the result queue if any.
         This function is supposed to run in a separate process.

--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -14,24 +14,26 @@ class TestRQJobUtils:
     """Test RQ-related utilities."""
 
     @staticmethod
-    def test_launch_simulation_from_rq_job():
+    def fn(queue, **kwargs):
+        # This helper function should be defined in a global scope, so Python can dump it when
+        # starting the process.
+        """Launch simulation and push the exception in the result queue if any.
+        This function is supposed to run in a separate process.
+        """
+        try:
+            launch_simulation_from_rq_job(**kwargs)
+        except Exception as exc:  # noqa
+            queue.put(exc)
+            raise exc
+
+    def test_launch_simulation_from_rq_job(self):
         """Assure the launch_simulation_from_rq_job can successfully launch a simulation.
         The launch_simulation_from_rq_job is ran in another process to ensure that its changes on
         constant settings will not cause other tests to fail.
         """
 
-        def fn(queue, **kwargs):
-            """Launch simulation and push the exception in the result queue if any.
-            This function is supposed to run in a separate process.
-            """
-            try:
-                launch_simulation_from_rq_job(**kwargs)
-            except Exception as exc:  # noqa
-                queue.put(exc)
-                raise exc
-
         results_queue = Queue()
-        process = Process(target=fn, args=(results_queue,), kwargs={
+        process = Process(target=self.fn, args=(results_queue,), kwargs={
             "scenario": zlib.compress(pickle.dumps("default_2a")),
             "settings": {
                "duration": duration(days=1),


### PR DESCRIPTION
## Reason for the proposed changes

Python can't pickle a local object when using multiprocessing.Process, thus the fn function is moved to the scope of TestRQJobUtils.

## Proposed changes

- Move helper function `fn` to a non-local scope

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
