### PR TITLE
Use exception logs to log simulation errors

### DIFF
--- a/src/gsy_e/gsy_e_core/exchange_jobs.py
+++ b/src/gsy_e/gsy_e_core/exchange_jobs.py
@@ -56,7 +56,7 @@ def main():
         try:
             worker.work(max_jobs=1, burst=True, logging_level="ERROR")
         except Exception as ex:  # pylint: disable=broad-except
-            logger.error(ex)
+            logger.exception(ex)
             worker.kill_horse()
             worker.wait_for_horse()
 

--- a/src/gsy_e/gsy_e_core/exchange_jobs.py
+++ b/src/gsy_e/gsy_e_core/exchange_jobs.py
@@ -18,38 +18,44 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 from os import environ, getpid
 
-from gsy_e.gsy_e_core.util import get_simulation_queue_name
 from pendulum import now
 from redis import Redis
 from rq import Connection, Worker, get_current_job
 from rq.decorators import job
 
+from gsy_e.gsy_e_core.util import get_simulation_queue_name
+
 logger = logging.getLogger()
 
 
-@job('exchange')
+@job("exchange")
 def start(scenario, settings, events, aggregator_device_mapping, saved_state):
+    """Start a simulation with a Redis job."""
+    # pylint: disable-next=import-outside-toplevel
     from gsy_e.gsy_e_core.rq_job_handler import launch_simulation_from_rq_job
-    job = get_current_job()
-    job.save_meta()
-    launch_simulation_from_rq_job(scenario, settings, events, aggregator_device_mapping,
-                                  saved_state, job.id)
+    current_job = get_current_job()
+    current_job.save_meta()
+    launch_simulation_from_rq_job(
+        scenario=scenario,
+        settings=settings,
+        events=events,
+        aggregator_device_mapping=aggregator_device_mapping,
+        saved_state=saved_state,
+        job_id=current_job.id
+    )
 
 
 def main():
+    """Main entrypoint for running the exchange jobs."""
     with Connection(
-        Redis.from_url(
-            environ.get('REDIS_URL', 'redis://localhost'),
-            retry_on_timeout=True
-        )
-    ):
+            Redis.from_url(environ.get("REDIS_URL", "redis://localhost"), retry_on_timeout=True)):
         worker = Worker(
             [get_simulation_queue_name()],
-            name=f'simulation.{getpid()}.{now().timestamp()}', log_job_description=False
+            name=f"simulation.{getpid()}.{now().timestamp()}", log_job_description=False
         )
         try:
             worker.work(max_jobs=1, burst=True, logging_level="ERROR")
-        except Exception as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             logger.error(ex)
             worker.kill_horse()
             worker.wait_for_horse()


### PR DESCRIPTION
## Reason for the proposed changes

In the dev logs I'm seeing a generic error:
```
Log message: TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```
This kind of error log doesn't make it easy to debug the issue, as it doesn't contain a traceback to understand where in the code the error appeared.

## Proposed changes

- Change the log level of the simulation entrypoint to be `exception` (which shows the traceback).
