### PR TITLE
Bump mkdocs version and related packages

### DIFF
--- a/wiki/requirements.txt
+++ b/wiki/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.0.4
 md-tooltips==1.3.1
-mkdocs-redirects==1.0.1
+mkdocs-redirects==1.0.4
+mkdocs==1.3.0


### PR DESCRIPTION
## Reason for the proposed changes

Running mkdocs currently raises the following error:
```sh
AttributeError: module 'jinja2' has no attribute 'contextfilter'
```

This happens because the old mkdocs version is incompatible with jinja2 3.1.0 release. See:
- https://github.com/mkdocs/mkdocs/issues/2799

## Proposed changes

- Update mkdocs.
