### PR TITLE
fix colorlog import

### DIFF
--- a/src/gsy_e/gsy_e_core/cli.py
+++ b/src/gsy_e/gsy_e_core/cli.py
@@ -23,7 +23,7 @@ from multiprocessing import Process
 import click
 from click.types import Choice
 from click_default_group import DefaultGroup
-from colorlog.colorlog import ColoredFormatter
+from colorlog import ColoredFormatter
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.exceptions import GSyException
 from gsy_framework.settings_validators import validate_global_settings


### PR DESCRIPTION
## Reason for the proposed changes

I get the error that colorlog is not valid.
This seems to have change in one of the latest versions of the package.

This issue occurs when installing with `pip install -e .`

**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
