### PR TITLE
GSYE-263: Added splitting of base energy bill to find portion of the …

### DIFF
--- a/src/gsy_e/setup/gsy_e_settings.json
+++ b/src/gsy_e/setup/gsy_e_settings.json
@@ -4,7 +4,7 @@
     "slot_length": "15m",
     "tick_length": "15s",
     "cloud_coverage": 0,
-    "start_date": "2022-07-08"
+    "start_date": "2022-07-29"
   },
   "advanced_settings": {
     "GeneralSettings": {
@@ -44,7 +44,11 @@
       "RELATIVE_STD_FROM_FORECAST_FLOAT": 10.0
     },
     "FutureMarketSettings": {
+      "FUTURE_MARKET_DURATION_HOURS": 0,
       "FUTURE_MARKET_CLEARING_INTERVAL_MINUTES": 15
+    },
+    "ForwardMarketSettings": {
+      "ENABLE_FORWARD_MARKETS": false
     },
     "AreaSettings": {
       "PERCENTAGE_FEE_LIMIT": [

--- a/tests/area/test_coefficient_area.py
+++ b/tests/area/test_coefficient_area.py
@@ -149,12 +149,15 @@ class TestCoefficientArea:
 
         # energy need * normal market maker fees for the case of positive energy need
         assert isclose(scm._bills[house1.uuid].base_energy_bill, 0.06)
+        assert isclose(scm._bills[house1.uuid].base_energy_bill_excl_revenue, 0.06)
+        assert isclose(scm._bills[house1.uuid].base_energy_bill_revenue, 0.0)
         assert isclose(scm._bills[house1.uuid].gsy_energy_bill, 0.06)
         assert isclose(scm._bills[house1.uuid].savings, 0.0)
         assert isclose(scm._bills[house1.uuid].savings_percent, 0.0)
         # energy surplus * feed in tariff for the case of positive energy surplus
         assert isclose(scm._bills[house2.uuid].base_energy_bill, -0.005)
-        # TODO: this part is failing
+        assert isclose(scm._bills[house2.uuid].base_energy_bill_excl_revenue, 0.0)
+        assert isclose(scm._bills[house2.uuid].base_energy_bill_revenue, 0.005)
         assert isclose(scm._bills[house2.uuid].gsy_energy_bill, -0.0164)
         assert isclose(scm._bills[house2.uuid].savings, 0.0114)
         assert isclose(scm._bills[house2.uuid].savings_percent, 0.0)


### PR DESCRIPTION
…bill that was originated by revenue and expenditure accordingly.

Required for the Savings KPI, in order to calculate these the base energy cost needed to be split in revenue / non revenue parts, in order to use the cost of the energy without the revenue for these calculations. 

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
