### PR TITLE
GSYE-370: Converted the daily_load_profile argument of the SCMLoadPro…

### DIFF
--- a/src/gsy_e/models/strategy/scm/load.py
+++ b/src/gsy_e/models/strategy/scm/load.py
@@ -59,7 +59,7 @@ class SCMLoadHoursStrategy(SCMStrategy):
 
 class SCMLoadProfile(SCMStrategy):
     """Load SCM strategy with power production dictated by a profile."""
-    def __init__(self, daily_load_profile, daily_load_profile_uuid=None):
+    def __init__(self, daily_load_profile=None, daily_load_profile_uuid=None):
         self._energy_params = DefinedLoadEnergyParameters(
             daily_load_profile, daily_load_profile_uuid)
 


### PR DESCRIPTION
…file to optional.

## Reason for the proposed changes

Please view the surrounding documents of this log for the root cause. The daily_load_profile parameter was mandatory but was never populated from the gsy-web / UI. The parameter can be optional though since it is not mandatory if the profile uuid is provided. 

https://kibana.production.gridsingularity.com/app/discover#/doc/62ff47d0-4520-11ec-a9a4-0b7ad4b10190/kubernetes_cluster-2022.08.01?id=7RGCWYIBkYWKMeH_Esal


## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
