### PR TITLE
GSYE-369: Added control in order to start simulation based on pod memory usage

### DIFF
--- a/src/gsy_e/gsy_e_core/launcher.py
+++ b/src/gsy_e/gsy_e_core/launcher.py
@@ -26,10 +26,11 @@ from subprocess import Popen
 from time import sleep
 import platform
 from gsy_framework.utils import check_redis_health
-from gsy_e.gsy_e_core.util import get_simulation_queue_name
+from gsy_e.gsy_e_core.util import get_simulation_queue_name, memory_usage_percent
 
 REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost')
 MAX_JOBS = os.environ.get('D3A_MAX_JOBS_PER_POD', 2)
+MAX_LIMIT_MEMORY_USAGE_PERCENT = os.environ.get('D3A_MAX_MEM_USAGE_PERCENT', 90)
 
 
 class Launcher:
@@ -48,8 +49,10 @@ class Launcher:
         self.job_array.append(self._start_worker())
         while True:
             sleep(1)
+
             if len(self.job_array) < self.max_jobs and self.is_queue_crowded():
-                self.job_array.append(self._start_worker())
+                if memory_usage_percent() <= MAX_LIMIT_MEMORY_USAGE_PERCENT:
+                    self.job_array.append(self._start_worker())
 
             self.job_array = [j for j in self.job_array if j.poll() is None]
 

--- a/src/gsy_e/gsy_e_core/util.py
+++ b/src/gsy_e/gsy_e_core/util.py
@@ -497,3 +497,23 @@ def is_time_slot_in_past_markets(time_slot: DateTime, current_time_slot: DateTim
         return (time_slot < current_time_slot.subtract(
             hours=ConstSettings.SettlementMarketSettings.MAX_AGE_SETTLEMENT_MARKET_HOURS))
     return time_slot < current_time_slot
+
+
+def memory_usage_percent():
+    """Returns the percentage of limit utilization."""
+    memory_limit_file = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    memory_usage_file = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+
+    try:
+        with open(memory_limit_file, "r") as limit:
+            mem_limit = limit.read()
+    except OSError:
+        return 0
+
+    try:
+        with open(memory_usage_file, "r") as usage:
+            mem_usage = usage.read()
+    except OSError:
+        return 0
+
+    return round(int(mem_usage) / int(mem_limit) * 100)


### PR DESCRIPTION
## Reason for the proposed changes

Based on [GSYE-369](https://gridsingularity.atlassian.net/browse/GSYE-369) issue while running Simulation/CN get stuck in initializing state and does not run. It happens because of pod memory usage limit is reached.

## Proposed changes
Added function to check (based of specific files) whether to start the simulation.
