### PR TITLE
Added the is_scm parameter in the ResultsHandler constructor for the …

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -68,12 +68,15 @@ class SimulationEndpointBuffer:
 
         self.bids_offers_trades = {}
         self.last_energy_trades_high_resolution = {}
-        self.results_handler = ResultsHandler(should_export_plots)
+        self.results_handler = self._create_endpoint_buffer(should_export_plots)
         self.simulation_state = {"general": {}, "areas": {}}
 
         if (ConstSettings.GeneralSettings.EXPORT_OFFER_BID_TRADE_HR or
                 ConstSettings.GeneralSettings.EXPORT_ENERGY_TRADE_PROFILE_HR):
             self.offer_bid_trade_hr = OfferBidTradeGraphStats()
+
+    def _create_endpoint_buffer(self, should_export_plots):
+        return ResultsHandler(should_export_plots)
 
     def prepare_results_for_publish(self) -> Dict:
         """Validate, serialise and check size of the results before sending to gsy-web."""
@@ -312,6 +315,9 @@ class CoefficientEndpointBuffer(SimulationEndpointBuffer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._scm_manager = None
+
+    def _create_endpoint_buffer(self, should_export_plots):
+        return ResultsHandler(should_export_plots, is_scm=True)
 
     def update_coefficient_stats(
             self, area: "AreaBase", simulation_status: str,

--- a/tests/strategies/test_strategy_infinite_bus.py
+++ b/tests/strategies/test_strategy_infinite_bus.py
@@ -43,6 +43,7 @@ def auto_fixture():
     ConstSettings.MASettings.MARKET_TYPE = 1
     ConstSettings.BalancingSettings.ENABLE_BALANCING_MARKET = False
     DeviceRegistry.REGISTRY = {}
+    GlobalConfig.FEED_IN_TARIFF = 20
 
 
 # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
…case that the coefficients market are enabled, in which case the CoefficientEndpointBuffer will be used instead of the normal SimulationEndpointBuffer.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
