### PR TITLE
GSYE-370: Corrected calculation of the minutes that the slot length c…

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -318,7 +318,12 @@ class CoefficientEndpointBuffer(SimulationEndpointBuffer):
             progress_info: "SimulationProgressInfo", sim_state: Dict,
             calculate_results: bool, scm_manager: "SCMManager") -> None:
         self._scm_manager = scm_manager
+
         self.current_market_time_slot_str = progress_info.current_slot_str
+        if progress_info.current_slot_time:
+            self.current_market_time_slot = progress_info.current_slot_time
+            self.current_market_time_slot_unix = progress_info.current_slot_time.timestamp()
+
         super().update_stats(
             area, simulation_status, progress_info, sim_state, calculate_results)
 

--- a/src/gsy_e/gsy_e_core/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation.py
@@ -83,7 +83,7 @@ class SimulationProgressInfo:
     @staticmethod
     def _get_market_slot_time(slot_number: int, config: "SimulationConfig") -> DateTime:
         return config.start_date.add(
-            minutes=config.slot_length.minutes * slot_number
+            minutes=config.slot_length.total_minutes() * slot_number
         )
 
     def update(self, slot_no: int, slot_count: int, time_params: "SimulationTimeManager",


### PR DESCRIPTION
…omprises of by using the total_minutes() method and not the minutes member, the latter just returns the minutes of the hour. The outcome of this was that for the 60 min slot length, the simulation results were not generated because the current_market_time_slot_str was always the start time (due to the fact that slot_length.minutes was always 0 for the case of slot length == 1 hour).

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
