### PR TITLE
Fix forward market clock and mapping

### DIFF
--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -666,6 +666,8 @@ class Area(AreaBase):
             self.future_markets.update_clock(self.now)
             for market in self._markets.settlement_markets.values():
                 market.update_clock(self.now)
+            for market in self._markets.forward_markets.values():
+                market.update_clock(self.now)
         for child in self.children:
             child.execute_actions_after_tick_event()
 

--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -639,6 +639,8 @@ class Area(AreaBase):
 
         forward_markets_mapping = {
             "current_time": self.now,
+            AvailableMarketTypes.INTRADAY:
+                self.forward_markets.get(AvailableMarketTypes.INTRADAY),
             AvailableMarketTypes.DAY_FORWARD:
                 self.forward_markets.get(AvailableMarketTypes.DAY_FORWARD),
             AvailableMarketTypes.WEEK_FORWARD:


### PR DESCRIPTION
## Reason for the proposed changes

1. Forward markets are missing the clock updates to track the creation time of the orders and trades.
2. We iterate through [_forward_match_algorithms](https://github.com/gridsingularity/gsy-e/blob/964d7a9e65c51acdaa281ed4e84a2c47ad50aebc/src/gsy_e/models/myco_matcher/myco_matcher_forward.py#L54) and trying to get the proper market from [area_uuid_markets_mapping](https://github.com/gridsingularity/gsy-e/blob/964d7a9e65c51acdaa281ed4e84a2c47ad50aebc/src/gsy_e/models/myco_matcher/myco_matcher_forward.py#L58), but the INTRADAY is missing.
 
## Proposed changes
1. Update the clock of the forward markets
2. Add intraday market to forward_markets_mapping

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
