### PR TITLE
Changed the Area class parameter deserialization, to deserialize the …

### DIFF
--- a/src/gsy_e/gsy_e_core/area_serializer.py
+++ b/src/gsy_e/gsy_e_core/area_serializer.py
@@ -155,25 +155,22 @@ def area_from_dict(description, config):
         else:
             children = None
 
-        coefficient_percentage = description.get("coefficient_percentage", 0.0)
         grid_fee_percentage = description.get("grid_fee_percentage", None)
         grid_fee_constant = description.get("grid_fee_constant", None)
-        taxes_surcharges = description.get("taxes_surcharges", 0.0)
-        fixed_monthly_fee = description.get("fixed_monthly_fee", 0.0)
-        marketplace_monthly_fee = description.get("marketplace_monthly_fee", 0.0)
-        market_maker_rate = description.get(
-            "market_maker_rate", ConstSettings.GeneralSettings.DEFAULT_MARKET_MAKER_RATE / 100.)
-        feed_in_tariff = description.get("feed_in_tariff", GlobalConfig.FEED_IN_TARIFF / 100.,)
+
         if ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.COEFFICIENTS.value:
             # For the SCM only use the CoefficientArea strategy.
             area = CoefficientArea(
                 name, children, uuid, optional("strategy"), config,
-                coefficient_percentage=coefficient_percentage,
-                taxes_surcharges=taxes_surcharges,
-                fixed_monthly_fee=fixed_monthly_fee,
-                marketplace_monthly_fee=marketplace_monthly_fee,
-                market_maker_rate=market_maker_rate,
-                feed_in_tariff=feed_in_tariff,
+                coefficient_percentage=description.get("coefficient_percentage", 0.0),
+                taxes_surcharges=description.get("taxes_surcharges", 0.0),
+                fixed_monthly_fee=description.get("fixed_monthly_fee", 0.0),
+                marketplace_monthly_fee=description.get("marketplace_monthly_fee", 0.0),
+                market_maker_rate=description.get(
+                    "market_maker_rate",
+                    ConstSettings.GeneralSettings.DEFAULT_MARKET_MAKER_RATE / 100.),
+                feed_in_tariff=description.get(
+                    "feed_in_tariff", GlobalConfig.FEED_IN_TARIFF / 100.,),
                 grid_fee_percentage=grid_fee_percentage,
                 grid_fee_constant=grid_fee_constant)
         else:

--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -273,7 +273,7 @@ class CoefficientArea(AreaBase):
         super().__init__(name, children, uuid, strategy, config, grid_fee_percentage,
                          grid_fee_constant)
         self.display_type = (
-            "CoeficientArea" if self.strategy is None else self.strategy.__class__.__name__)
+            "CoefficientArea" if self.strategy is None else self.strategy.__class__.__name__)
         self.coefficient_percentage = coefficient_percentage
         self._taxes_surcharges = taxes_surcharges
         self._fixed_monthly_fee = fixed_monthly_fee

--- a/tests/test_area_serializer.py
+++ b/tests/test_area_serializer.py
@@ -190,6 +190,13 @@ def test_leaf_deserialization_scm():
     recovered = area_from_string(
         '''{
              "name": "house",
+             "grid_fee_constant": 0.3,
+             "coefficient_percentage": 0.4,
+             "taxes_surcharges": 0.5,
+             "fixed_monthly_fee": 0.6,
+             "marketplace_monthly_fee": 0.7,
+             "feed_in_tariff": 0.8,
+             "market_maker_rate": 0.9,
              "children":[
                  {"name": "pv1", "type": "PV", "capacity_kW": 4},
                  {"name": "pv1", "type": "PredefinedPV", "cloud_coverage": 1},
@@ -205,6 +212,13 @@ def test_leaf_deserialization_scm():
         _create_config()
     )
 
+    assert recovered.grid_fee_constant == 0.3
+    assert recovered.coefficient_percentage == 0.4
+    assert recovered._taxes_surcharges == 0.5
+    assert recovered._fixed_monthly_fee == 0.6
+    assert recovered._marketplace_monthly_fee == 0.7
+    assert recovered._feed_in_tariff == 0.8
+    assert recovered.market_maker_rate == 0.9
     assert isinstance(recovered.children[0], SCMPV)
     assert isinstance(recovered.children[0].strategy, SCMPVStrategy)
     assert recovered.children[0].strategy._energy_params.capacity_kW == 4


### PR DESCRIPTION
…SCM parameters only for the case of Coefficients market and not for the normal exchanges.

## Reason for the proposed changes

Bugfix for this [error](https://kibana.production.gridsingularity.com/app/discover#/context/62ff47d0-4520-11ec-a9a4-0b7ad4b10190/nBBufoIBrELqbkkEFP-D?_g=(filters:!())&_a=(columns:!(kubernetes.labels.app,log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!t,index:'62ff47d0-4520-11ec-a9a4-0b7ad4b10190',key:kubernetes.namespace_name,negate:!f,params:(query:d3a-production),type:phrase),query:(match_phrase:(kubernetes.namespace_name:d3a-production))),('$state':(store:appState),meta:(alias:!n,controlledBy:'1637085574682',disabled:!t,index:'62ff47d0-4520-11ec-a9a4-0b7ad4b10190',key:kubernetes.labels.app.keyword,negate:!f,params:!(d3a-simulation-cn-production,d3a-simulation-production),type:phrases),query:(bool:(minimum_should_match:1,should:!((match_phrase:(kubernetes.labels.app.keyword:d3a-simulation-cn-production)),(match_phrase:(kubernetes.labels.app.keyword:d3a-simulation-production)))))))))

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
