### PR TITLE
GSYE-373-2: Use AvailableMarketTypes.value instead of AvailableMarketTypes

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -204,7 +204,7 @@ class SimulationEndpointBuffer:
         for market_type, market in area.forward_markets.items():
             for time_slot in market.market_time_slots:
                 time_slot_str = time_slot.format(DATE_TIME_FORMAT)
-                stats_dict[market_type][time_slot_str] = {
+                stats_dict[market_type.value][time_slot_str] = {
                     "bids": self._get_future_orders_from_timeslot(
                         market.bid_history, time_slot),
                     "offers": self._get_future_orders_from_timeslot(


### PR DESCRIPTION
## Reason for the proposed changes
AvailableMarketTypes objects are not json serializable.

## Proposed changes

- Use AvailableMarketTypes.value

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
