### PR TITLE
PH-1285: get_energy_to_buy_kWh method was not overridden in the SCMLo…

### DIFF
--- a/src/gsy_e/models/strategy/scm/load.py
+++ b/src/gsy_e/models/strategy/scm/load.py
@@ -90,3 +90,7 @@ class SCMLoadProfileStrategy(SCMStrategy):
         """Decrease traded energy from the state and the strategy parameters."""
         self._energy_params.state.decrement_energy_requirement(
             traded_energy_kWh, time_slot, area.name)
+
+    def get_energy_to_buy_kWh(self, time_slot: DateTime) -> float:
+        """Get the available energy for consumption for the specified time slot."""
+        return self._energy_params.state.get_energy_requirement_Wh(time_slot) / 1000.0


### PR DESCRIPTION
…adProfileStrategy class, thus the consumption profile was not followed and only 0 was reported due to the base class implementation of the method.

## Reason for the proposed changes

The consumption profile was always 0 for the load (PVs were working well) despite the fact that the profile timestamps aligned with the start time of the simulation. Root cause was that the method that retrieved the energy requirement for the load profiles from the state was not overridden, thus returning always 0. 

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
