### PR TITLE
GSYE-377: Split the LoadForecastExternalStrategy to 2 classes, LoadPr…

### DIFF
--- a/src/gsy_e/models/leaves.py
+++ b/src/gsy_e/models/leaves.py
@@ -20,9 +20,9 @@ import logging
 
 from gsy_e.models.area import Area, CoefficientArea
 from gsy_e.models.strategy.commercial_producer import CommercialStrategy
-from gsy_e.models.strategy.external_strategies.load import (LoadForecastExternalStrategy,
-                                                            LoadHoursExternalStrategy,
-                                                            LoadProfileExternalStrategy)
+from gsy_e.models.strategy.external_strategies.load import (
+    LoadHoursForecastExternalStrategy, LoadProfileForecastExternalStrategy,
+    LoadHoursExternalStrategy, LoadProfileExternalStrategy)
 from gsy_e.models.strategy.external_strategies.pv import (PVExternalStrategy,
                                                           PVForecastExternalStrategy,
                                                           PVPredefinedExternalStrategy,
@@ -56,8 +56,8 @@ forecast_strategy_mapping = {
     PVPredefinedStrategy: PVForecastExternalStrategy,
     PVStrategy: PVForecastExternalStrategy,
     PVUserProfileStrategy: PVForecastExternalStrategy,
-    DefinedLoadStrategy: LoadForecastExternalStrategy,
-    LoadHoursStrategy: LoadForecastExternalStrategy
+    DefinedLoadStrategy: LoadProfileForecastExternalStrategy,
+    LoadHoursStrategy: LoadHoursForecastExternalStrategy
 }
 
 scm_strategy_mapping = {
@@ -135,15 +135,15 @@ class LeafBase:
         return self.strategy.serialize()
 
 
+# pylint: disable=missing-class-docstring
+
+
 class Leaf(LeafBase, Area):
     pass
 
 
 class CoefficientLeaf(LeafBase, CoefficientArea):
     pass
-
-
-# pylint: disable=missing-class-docstring
 
 
 class CommercialProducer(Leaf):

--- a/src/gsy_e/models/strategy/external_strategies/load.py
+++ b/src/gsy_e/models/strategy/external_strategies/load.py
@@ -27,7 +27,7 @@ from gsy_e.models.strategy.external_strategies import (CommandTypeNotSupported, 
                                                        ExternalStrategyConnectionManager,
                                                        IncomingRequest, OrderCanNotBePosted)
 from gsy_e.models.strategy.external_strategies.forecast_mixin import ForecastExternalMixin
-from gsy_e.models.strategy.load_hours import LoadHoursStrategy, LoadHoursEnergyParameters
+from gsy_e.models.strategy.load_hours import LoadHoursStrategy, LoadHoursPerDayEnergyParameters
 from gsy_e.models.strategy.predefined_load import DefinedLoadEnergyParameters, DefinedLoadStrategy
 
 if TYPE_CHECKING:
@@ -401,7 +401,7 @@ class LoadProfileForecastEnergyParams(
 
 
 class LoadHoursForecastEnergyParams(
-        LoadForecastExternalEnergyParamsMixin, LoadHoursEnergyParameters):
+        LoadForecastExternalEnergyParamsMixin, LoadHoursPerDayEnergyParameters):
     """Energy parameters class for the forecasted external load hours strategy."""
 
 
@@ -493,7 +493,7 @@ class LoadHoursForecastExternalStrategy(
                   ConstSettings.BalancingSettings.OFFER_SUPPLY_RATIO),
                  use_market_maker_rate: bool = False,
                  avg_power_W=0,
-                 hrs_per_day=0,  # Keeping for backwards compatibility
+                 hrs_per_day=0,
                  hrs_of_day=None):
         """
         Constructor of LoadForecastStrategy
@@ -502,7 +502,7 @@ class LoadHoursForecastExternalStrategy(
             update_interval = duration(
                 minutes=ConstSettings.GeneralSettings.DEFAULT_UPDATE_INTERVAL)
 
-        super().__init__(daily_load_profile=None,
+        super().__init__(None,
                          fit_to_limit=fit_to_limit,
                          energy_rate_increase_per_update=energy_rate_increase_per_update,
                          update_interval=update_interval,
@@ -512,4 +512,4 @@ class LoadHoursForecastExternalStrategy(
                          use_market_maker_rate=use_market_maker_rate)
 
         self._energy_params = LoadHoursForecastEnergyParams(
-            avg_power_W, hrs_of_day)
+            avg_power_W, hrs_per_day, hrs_of_day)

--- a/src/gsy_e/models/strategy/external_strategies/load.py
+++ b/src/gsy_e/models/strategy/external_strategies/load.py
@@ -27,7 +27,7 @@ from gsy_e.models.strategy.external_strategies import (CommandTypeNotSupported, 
                                                        ExternalStrategyConnectionManager,
                                                        IncomingRequest, OrderCanNotBePosted)
 from gsy_e.models.strategy.external_strategies.forecast_mixin import ForecastExternalMixin
-from gsy_e.models.strategy.load_hours import LoadHoursStrategy
+from gsy_e.models.strategy.load_hours import LoadHoursStrategy, LoadHoursEnergyParameters
 from gsy_e.models.strategy.predefined_load import DefinedLoadEnergyParameters, DefinedLoadStrategy
 
 if TYPE_CHECKING:
@@ -382,7 +382,7 @@ class LoadProfileExternalStrategy(LoadExternalMixin, DefinedLoadStrategy):
     """Concrete DefinedLoadStrategy class with external connection capabilities"""
 
 
-class LoadForecastExternalEnergyParams(DefinedLoadEnergyParameters):
+class LoadForecastExternalEnergyParamsMixin:
     """
     Energy parameters for LoadForecastExternalStrategy class. Mostly used to override / disable
     methods of the DefinedLoadEnergyParameters.
@@ -395,43 +395,20 @@ class LoadForecastExternalEnergyParams(DefinedLoadEnergyParameters):
         """Overridden with empty implementation to disable profile activation."""
 
 
-class LoadForecastExternalStrategy(ForecastExternalMixin, LoadProfileExternalStrategy):
+class LoadProfileForecastEnergyParams(
+        LoadForecastExternalEnergyParamsMixin, DefinedLoadEnergyParameters):
+    """Energy parameters class for the forecasted external load profile strategy."""
+
+
+class LoadHoursForecastEnergyParams(
+        LoadForecastExternalEnergyParamsMixin, LoadHoursEnergyParameters):
+    """Energy parameters class for the forecasted external load hours strategy."""
+
+
+class LoadForecastExternalStrategyMixin(ForecastExternalMixin):
     """
         Strategy responsible for reading forecast and measurement consumption data via hardware API
     """
-    # pylint: disable=too-many-arguments
-    def __init__(self, fit_to_limit=True, energy_rate_increase_per_update=None,
-                 update_interval=None,
-                 initial_buying_rate: Union[float, dict, str] =
-                 ConstSettings.LoadSettings.BUYING_RATE_RANGE.initial,
-                 final_buying_rate: Union[float, dict, str] =
-                 ConstSettings.LoadSettings.BUYING_RATE_RANGE.final,
-                 balancing_energy_ratio: tuple =
-                 (ConstSettings.BalancingSettings.OFFER_DEMAND_RATIO,
-                  ConstSettings.BalancingSettings.OFFER_SUPPLY_RATIO),
-                 use_market_maker_rate: bool = False,
-                 avg_power_W=0,
-                 hrs_per_day=0,
-                 hrs_of_day=None,
-                 daily_load_profile=None,
-                 daily_load_profile_uuid=None):
-        """
-        Constructor of LoadForecastStrategy
-        """
-        if update_interval is None:
-            update_interval = duration(
-                minutes=ConstSettings.GeneralSettings.DEFAULT_UPDATE_INTERVAL)
-
-        super().__init__(daily_load_profile=None,
-                         fit_to_limit=fit_to_limit,
-                         energy_rate_increase_per_update=energy_rate_increase_per_update,
-                         update_interval=update_interval,
-                         final_buying_rate=final_buying_rate,
-                         initial_buying_rate=initial_buying_rate,
-                         balancing_energy_ratio=balancing_energy_ratio,
-                         use_market_maker_rate=use_market_maker_rate)
-
-        self._energy_params = LoadForecastExternalEnergyParams()
 
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""
@@ -455,3 +432,84 @@ class LoadForecastExternalStrategy(ForecastExternalMixin, LoadProfileExternalStr
         """
         Setting measured energy for the previous slot is already done by update_energy_measurement
         """
+
+
+class LoadProfileForecastExternalStrategy(
+        LoadForecastExternalStrategyMixin, LoadProfileExternalStrategy):
+    """
+        Strategy responsible for reading forecast and measurement consumption data via hardware
+        API. In case the hardware API is not available the normal profile strategy will be used
+        instead.
+    """
+    # pylint: disable=too-many-arguments
+    def __init__(self, fit_to_limit=True, energy_rate_increase_per_update=None,
+                 update_interval=None,
+                 initial_buying_rate: Union[float, dict, str] =
+                 ConstSettings.LoadSettings.BUYING_RATE_RANGE.initial,
+                 final_buying_rate: Union[float, dict, str] =
+                 ConstSettings.LoadSettings.BUYING_RATE_RANGE.final,
+                 balancing_energy_ratio: tuple =
+                 (ConstSettings.BalancingSettings.OFFER_DEMAND_RATIO,
+                  ConstSettings.BalancingSettings.OFFER_SUPPLY_RATIO),
+                 use_market_maker_rate: bool = False,
+                 daily_load_profile=None,
+                 daily_load_profile_uuid=None):
+        """
+        Constructor of LoadForecastStrategy
+        """
+        if update_interval is None:
+            update_interval = duration(
+                minutes=ConstSettings.GeneralSettings.DEFAULT_UPDATE_INTERVAL)
+
+        super().__init__(daily_load_profile=None,
+                         fit_to_limit=fit_to_limit,
+                         energy_rate_increase_per_update=energy_rate_increase_per_update,
+                         update_interval=update_interval,
+                         final_buying_rate=final_buying_rate,
+                         initial_buying_rate=initial_buying_rate,
+                         balancing_energy_ratio=balancing_energy_ratio,
+                         use_market_maker_rate=use_market_maker_rate)
+
+        self._energy_params = LoadProfileForecastEnergyParams(
+            daily_load_profile, daily_load_profile_uuid)
+
+
+class LoadHoursForecastExternalStrategy(
+        LoadForecastExternalStrategyMixin, LoadHoursExternalStrategy):
+    """
+        Strategy responsible for reading forecast and measurement consumption data via hardware
+        API. In case the hardware API is not available the normal load hours strategy will be used
+        instead.
+    """
+    # pylint: disable=too-many-arguments,unused-argument
+    def __init__(self, fit_to_limit=True, energy_rate_increase_per_update=None,
+                 update_interval=None,
+                 initial_buying_rate: Union[float, dict, str] =
+                 ConstSettings.LoadSettings.BUYING_RATE_RANGE.initial,
+                 final_buying_rate: Union[float, dict, str] =
+                 ConstSettings.LoadSettings.BUYING_RATE_RANGE.final,
+                 balancing_energy_ratio: tuple =
+                 (ConstSettings.BalancingSettings.OFFER_DEMAND_RATIO,
+                  ConstSettings.BalancingSettings.OFFER_SUPPLY_RATIO),
+                 use_market_maker_rate: bool = False,
+                 avg_power_W=0,
+                 hrs_per_day=0,  # Keeping for backwards compatibility
+                 hrs_of_day=None):
+        """
+        Constructor of LoadForecastStrategy
+        """
+        if update_interval is None:
+            update_interval = duration(
+                minutes=ConstSettings.GeneralSettings.DEFAULT_UPDATE_INTERVAL)
+
+        super().__init__(daily_load_profile=None,
+                         fit_to_limit=fit_to_limit,
+                         energy_rate_increase_per_update=energy_rate_increase_per_update,
+                         update_interval=update_interval,
+                         final_buying_rate=final_buying_rate,
+                         initial_buying_rate=initial_buying_rate,
+                         balancing_energy_ratio=balancing_energy_ratio,
+                         use_market_maker_rate=use_market_maker_rate)
+
+        self._energy_params = LoadHoursForecastEnergyParams(
+            avg_power_W, hrs_of_day)

--- a/tests/strategies/external/test_init.py
+++ b/tests/strategies/external/test_init.py
@@ -36,7 +36,8 @@ from gsy_e.models.strategy import BidEnabledStrategy
 from gsy_e.models.strategy.external_strategies import (
     IncomingRequest, ExternalStrategyConnectionManager)
 from gsy_e.models.strategy.external_strategies.load import (
-    LoadForecastExternalStrategy, LoadHoursExternalStrategy, LoadProfileExternalStrategy)
+    LoadHoursForecastExternalStrategy, LoadProfileForecastExternalStrategy,
+    LoadHoursExternalStrategy, LoadProfileExternalStrategy)
 from gsy_e.models.strategy.external_strategies.pv import (
     PVExternalStrategy, PVForecastExternalStrategy, PVPredefinedExternalStrategy,
     PVUserProfileExternalStrategy)
@@ -517,8 +518,10 @@ class TestExternalMixin:
 
 
 class TestForecastRelatedFeatures:
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
-                                                      PVForecastExternalStrategy()], indirect=True)
+    @pytest.mark.parametrize("ext_strategy_fixture", [
+        LoadHoursForecastExternalStrategy(),
+        LoadProfileForecastExternalStrategy(),
+        PVForecastExternalStrategy()], indirect=True)
     def test_set_energy_forecast_succeeds(self, ext_strategy_fixture):
         arguments = {"transaction_id": transaction_id,
                      "energy_forecast": {now().format(gsy_e.constants.DATE_TIME_FORMAT): 1}}
@@ -532,7 +535,8 @@ class TestForecastRelatedFeatures:
                 deque([IncomingRequest("set_energy_forecast", arguments,
                                        energy_forecast_response_channel)]))
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()], indirect=True)
     def test_set_energy_forecast_fails_for_wrong_payload(self, ext_strategy_fixture):
         ext_strategy_fixture.redis.publish_json = Mock()
@@ -548,7 +552,8 @@ class TestForecastRelatedFeatures:
                                                "transaction_id": transaction_id})
         assert len(ext_strategy_fixture.pending_requests) == 0
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()], indirect=True)
     def test_set_energy_measurement_succeeds(self, ext_strategy_fixture):
         arguments = {"transaction_id": transaction_id,
@@ -563,7 +568,8 @@ class TestForecastRelatedFeatures:
                 deque([IncomingRequest("set_energy_measurement", arguments,
                                        energy_measurement_response_channel)]))
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()],
                              indirect=True)
     def test_set_energy_measurement_fails_for_wrong_payload(self, ext_strategy_fixture):
@@ -581,7 +587,8 @@ class TestForecastRelatedFeatures:
                                                   "transaction_id": transaction_id})
         assert len(ext_strategy_fixture.pending_requests) == 0
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()], indirect=True)
     def test_set_energy_forecast_impl_succeeds(self, ext_strategy_fixture):
         ext_strategy_fixture.redis.publish_json = Mock()
@@ -594,7 +601,8 @@ class TestForecastRelatedFeatures:
                                "status": "ready",
                                "transaction_id": arguments["transaction_id"]})
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()],
                              indirect=True)
     def test_set_energy_forecast_impl_fails_for_wrong_time_format(self, ext_strategy_fixture):
@@ -611,7 +619,8 @@ class TestForecastRelatedFeatures:
                                "transaction_id": arguments["transaction_id"],
                                "error_message": error_message})
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()],
                              indirect=True)
     def test_set_energy_forecast_impl_fails_for_negative_energy(self, ext_strategy_fixture):
@@ -628,7 +637,8 @@ class TestForecastRelatedFeatures:
                                "transaction_id": arguments["transaction_id"],
                                "error_message": error_message})
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()], indirect=True)
     def test_set_energy_measurement_impl_succeeds(self, ext_strategy_fixture):
         # test successful call of set_energy_measurement_impl:
@@ -642,7 +652,8 @@ class TestForecastRelatedFeatures:
                                "status": "ready",
                                "transaction_id": arguments["transaction_id"]})
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()],
                              indirect=True)
     def test_set_energy_measurement_impl_fails_for_wrong_time_format(self, ext_strategy_fixture):
@@ -659,7 +670,8 @@ class TestForecastRelatedFeatures:
                                "transaction_id": arguments["transaction_id"],
                                "error_message": error_message})
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()],
                              indirect=True)
     def test_set_energy_measurement_impl_fails_for_negative_energy(self, ext_strategy_fixture):
@@ -676,7 +688,8 @@ class TestForecastRelatedFeatures:
                                "transaction_id": arguments["transaction_id"],
                                "error_message": error_message})
 
-    @pytest.mark.parametrize("ext_strategy", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy", [LoadHoursForecastExternalStrategy(),
+                                              LoadProfileForecastExternalStrategy(),
                                               PVForecastExternalStrategy()])
     @pytest.mark.parametrize("command_name", ["set_energy_forecast", "set_energy_measurement"])
     def test_set_device_energy_data_aggregator_succeeds(self, ext_strategy, command_name):

--- a/tests/test_external_strategies.py
+++ b/tests/test_external_strategies.py
@@ -20,8 +20,9 @@ import uuid
 import json
 import pytest
 from gsy_e.models.area import Area
-from gsy_e.models.strategy.external_strategies.load import (LoadForecastExternalStrategy,
-                                                            LoadHoursExternalStrategy)
+from gsy_e.models.strategy.external_strategies.load import (
+    LoadHoursForecastExternalStrategy, LoadProfileForecastExternalStrategy,
+    LoadHoursExternalStrategy)
 from gsy_e.models.strategy.external_strategies.pv import (PVForecastExternalStrategy,
                                                           PVExternalStrategy)
 from gsy_e.models.strategy.external_strategies.storage import StorageExternalStrategy
@@ -53,7 +54,8 @@ def ext_strategy_fixture(request):
 
 class TestPVForecastExternalStrategy:
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()], indirect=True)
     def test_event_market_cycle_calls_energy_update_methods(self, ext_strategy_fixture):
         ext_strategy_fixture.energy_forecast_buffer = {now(): 1}
@@ -88,7 +90,8 @@ class TestPVForecastExternalStrategy:
         ext_strategy_fixture.update_energy_forecast()
         ext_strategy_fixture.state.set_available_energy.assert_not_called()
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy()],
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy()],
                              indirect=True)
     def test_update_energy_forecast_calls_set_desired_energy(self, ext_strategy_fixture):
         time = ext_strategy_fixture.area.spot_market.time_slot
@@ -101,7 +104,8 @@ class TestPVForecastExternalStrategy:
             energy * 1000, time, overwrite=True)
         ext_strategy_fixture.state.update_total_demanded_energy.assert_called_once_with(time)
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy()],
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy()],
                              indirect=True)
     def test_update_energy_forecast_doesnt_call_set_desired_energy_for_past_markets(
             self, ext_strategy_fixture):
@@ -113,7 +117,8 @@ class TestPVForecastExternalStrategy:
         ext_strategy_fixture.state.set_desired_energy.assert_not_called()
         ext_strategy_fixture.state.update_total_demanded_energy.assert_not_called()
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()], indirect=True)
     def test_update_energy_measurement_calls_set_energy_measurement_kWh(
             self, ext_strategy_fixture):
@@ -124,7 +129,8 @@ class TestPVForecastExternalStrategy:
         ext_strategy_fixture.update_energy_measurement()
         ext_strategy_fixture.state.set_energy_measurement_kWh.assert_called_once_with(energy, time)
 
-    @pytest.mark.parametrize("ext_strategy_fixture", [LoadForecastExternalStrategy(),
+    @pytest.mark.parametrize("ext_strategy_fixture", [LoadHoursForecastExternalStrategy(),
+                                                      LoadProfileForecastExternalStrategy(),
                                                       PVForecastExternalStrategy()], indirect=True)
     def test_update_energy_measurement_doesnt_call_set_energy_measurement_kWh_for_future_markets(
             self, ext_strategy_fixture):

--- a/tests/test_live_events.py
+++ b/tests/test_live_events.py
@@ -69,6 +69,7 @@ class TestLiveEvents(unittest.TestCase):
 
     def tearDown(self) -> None:
         GlobalConfig.sim_duration = duration(days=GlobalConfig.DURATION_D)
+        GlobalConfig.FEED_IN_TARIFF = 20
 
     def test_create_area_event_is_creating_a_new_area(self):
         event_dict = {


### PR DESCRIPTION
…ofileForecastExternalStrategy and LoadHoursForecastExternalStrategy in order to separate the default behavior for the case that no forecast stream is available and the strategy has to fall back to default strategy profiles / energy values.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
