### PR TITLE
feature/GSYE-373-3: Filter bids/offers/trades of forward market based on current time_slot

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -177,7 +177,7 @@ class SimulationEndpointBuffer:
         return [order.serializable_dict()
                 for order in forward_orders
                 if order.time_slot == market_time_slot and
-                last_time_slot < order.creation_time <= current_time_slot]
+                last_time_slot <= order.creation_time < current_time_slot]
 
     def _read_future_markets_stats_to_dict(self, area: "Area") -> Dict[str, Dict]:
         """Read future markets and return market_stats in a dict."""

--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -177,7 +177,7 @@ class SimulationEndpointBuffer:
         return [order.serializable_dict()
                 for order in forward_orders
                 if order.time_slot == market_time_slot and
-                last_time_slot <= order.creation_time < current_time_slot]
+                last_time_slot < order.creation_time <= current_time_slot]
 
     def _read_future_markets_stats_to_dict(self, area: "Area") -> Dict[str, Dict]:
         """Read future markets and return market_stats in a dict."""


### PR DESCRIPTION
## Reason for the proposed changes

We want to transfer only bids/offers/trades that have happened in the current simulation time of forward markets. 

## Proposed changes
- Add `_get_current_forward_orders_from_timeslot`

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
