### PR TITLE
PH-1285: Adapted the update of available energy for the user profile …

### DIFF
--- a/src/gsy_e/models/strategy/scm/pv.py
+++ b/src/gsy_e/models/strategy/scm/pv.py
@@ -65,13 +65,16 @@ class SCMPVUserProfile(SCMPVStrategy):
         self._energy_params = PVUserProfileEnergyParameters(1, power_profile, power_profile_uuid)
         super().__init__()
 
-    def activate(self, area: "AreaBase") -> None:
-        self._energy_params.read_predefined_profile_for_pv()
-        super().activate(area)
-
-    def market_cycle(self, area: "AreaBase") -> None:
+    def _update_forecast_in_state(self, area):
         self._energy_params.read_predefined_profile_for_pv()
         self._energy_params.set_produced_energy_forecast_in_state(
             area.name, [area._current_market_time_slot], True
         )
-        super().market_cycle(area)
+
+    def activate(self, area: "AreaBase") -> None:
+        self._energy_params.activate(area.config)
+        self._update_forecast_in_state(area)
+
+    def market_cycle(self, area: "AreaBase") -> None:
+        self._update_forecast_in_state(area)
+        self.state.delete_past_state_values(area.past_market_time_slot)

--- a/tests/strategies/test_scm_strategy.py
+++ b/tests/strategies/test_scm_strategy.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+from gsy_e.models.area import CoefficientArea
+from gsy_e.models.strategy.profile import EnergyProfile
+from gsy_e.models.strategy.scm.pv import SCMPVUserProfile, PVUserProfileEnergyParameters
+from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy, DefinedLoadEnergyParameters
+
+
+class TestSCMPVStrategies:
+    # pylint: disable=protected-access
+    @staticmethod
+    def test_scm_pv_user_profile_strategy_updates_energy_forecast():
+        energy_params = MagicMock(spec=PVUserProfileEnergyParameters)
+        energy_params._state = MagicMock()
+        pv = SCMPVUserProfile()
+        area = CoefficientArea(name="pv", strategy=pv)
+
+        pv._energy_params = energy_params
+        pv.activate(area)
+        energy_params.read_predefined_profile_for_pv.assert_called_once()
+        energy_params.set_produced_energy_forecast_in_state.assert_called_once()
+
+        energy_params.reset_mock()
+        pv.market_cycle(area)
+        energy_params.read_predefined_profile_for_pv.assert_called_once()
+        energy_params.set_produced_energy_forecast_in_state.assert_called_once()
+
+
+class TestSCMLoadStrategies:
+
+    @staticmethod
+    def test_scm_load_profile_strategy_updates_energy_forecast():
+        # pylint: disable=protected-access
+        energy_params = MagicMock(spec=DefinedLoadEnergyParameters)
+        energy_params._energy_profile = MagicMock(spec=EnergyProfile)
+        load = SCMLoadProfileStrategy()
+        area = CoefficientArea(name="load", strategy=load)
+
+        load._energy_params = energy_params
+        load.activate(area)
+        energy_params.event_activate_energy.assert_called_once()
+
+        energy_params.reset_mock()
+        load.market_cycle(area)
+        energy_params._energy_profile.read_or_rotate_profiles.assert_called_once()
+        energy_params.update_energy_requirement.assert_called_once()


### PR DESCRIPTION
…SCM PV strategy, in order to not call the base class and not override the user uploaded profile with the predefined sunny profile.

## Reason for the proposed changes

After the changes the PV profiles seem to have applied correctly:

<img width="355" alt="Screenshot 2022-08-23 at 10 49 53" src="https://user-images.githubusercontent.com/37290802/186102303-fa2be92f-3f03-44aa-b761-a1e47fe840e0.png">


## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
