### PR TITLE
feature/GSYE-375: Move AvailableMarketTypes' definition to gsy-framework

### DIFF
--- a/src/gsy_e/gsy_e_core/enums.py
+++ b/src/gsy_e/gsy_e_core/enums.py
@@ -1,21 +1,4 @@
-from enum import Enum
-
-
-class AvailableMarketTypes(Enum):
-    """Collection of available market types
-    Needs to be in this module in order to circumvent circular imports
-    """
-
-    SPOT = 0
-    BALANCING = 1
-    SETTLEMENT = 2
-    FUTURE = 3
-    DAY_FORWARD = 4
-    WEEK_FORWARD = 5
-    MONTH_FORWARD = 6
-    YEAR_FORWARD = 7
-    INTRADAY = 8
-
+from gsy_framework.enums import AvailableMarketTypes
 
 PAST_MARKET_TYPE_FILE_SUFFIX_MAPPING = {
     AvailableMarketTypes.SPOT: "",

--- a/src/gsy_e/gsy_e_core/export.py
+++ b/src/gsy_e/gsy_e_core/export.py
@@ -21,30 +21,32 @@ import logging
 import os
 import pathlib
 import shutil
-from typing import Dict, Tuple, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from gsy_framework.constants_limits import ConstSettings
-from gsy_framework.data_classes import (
-    Trade, BalancingTrade, Bid, Offer, BalancingOffer, MarketClearingState)
-from gsy_framework.enums import BidOfferMatchAlgoEnum, SpotMarketTypeEnum
+from gsy_framework.data_classes import (BalancingOffer, BalancingTrade, Bid, MarketClearingState,
+                                        Offer, Trade)
+from gsy_framework.enums import AvailableMarketTypes, BidOfferMatchAlgoEnum, SpotMarketTypeEnum
 from gsy_framework.utils import mkdir_from_str
 from pendulum import DateTime
 
 import gsy_e.constants
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes, PAST_MARKET_TYPE_FILE_SUFFIX_MAPPING
+from gsy_e.gsy_e_core.enums import PAST_MARKET_TYPE_FILE_SUFFIX_MAPPING
 from gsy_e.gsy_e_core.myco_singleton import bid_offer_matcher
 from gsy_e.gsy_e_core.sim_results.file_export_endpoints import file_export_endpoints_factory
-from gsy_e.gsy_e_core.sim_results.results_plots import (
-    PlotAverageTradePrice, PlotESSSOCHistory, PlotESSEnergyTrace, PlotOrderInfo,
-    PlotEnergyTradeProfileHR, PlotSupplyDemandCurve, PlotEnergyProfile, PlotUnmatchedLoads,
-    PlotDeviceStats)
+from gsy_e.gsy_e_core.sim_results.results_plots import (PlotAverageTradePrice, PlotDeviceStats,
+                                                        PlotEnergyProfile,
+                                                        PlotEnergyTradeProfileHR,
+                                                        PlotESSEnergyTrace, PlotESSSOCHistory,
+                                                        PlotOrderInfo, PlotSupplyDemandCurve,
+                                                        PlotUnmatchedLoads)
 from gsy_e.gsy_e_core.util import constsettings_to_dict
 from gsy_e.models.area import Area
 
 if TYPE_CHECKING:
-    from gsy_e.models.market.future import FutureMarkets
     from gsy_e.gsy_e_core.sim_results.endpoint_buffer import SimulationEndpointBuffer
     from gsy_e.models.area.scm_manager import SCMManager
+    from gsy_e.models.market.future import FutureMarkets
 
 _log = logging.getLogger(__name__)
 

--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -167,9 +167,10 @@ class SimulationEndpointBuffer:
                 if order.time_slot == time_slot]
 
     @staticmethod
-    def _get_current_forward_orders_from_timeslot(forward_orders: List,
-                                                  market_time_slot: DateTime,
-                                                  area: "Area") -> List:
+    def _get_current_forward_orders_from_timeslot(
+            forward_orders: List,
+            market_time_slot: DateTime,
+            area: "Area") -> List:
         """Filter orders that have happened in the current simulation time for
         the specified market time slot."""
         current_time_slot = area.now

--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -21,12 +21,12 @@ from typing import TYPE_CHECKING, Dict, List
 
 from gsy_framework.constants_limits import (DATE_TIME_FORMAT, DATE_TIME_UI_FORMAT, ConstSettings,
                                             GlobalConfig)
+from gsy_framework.enums import AvailableMarketTypes
 from gsy_framework.results_validator import results_validator
 from gsy_framework.sim_results.all_results import ResultsHandler
 from gsy_framework.utils import get_json_dict_memory_allocation_size
 from pendulum import DateTime
 
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 from gsy_e.gsy_e_core.sim_results.offer_bids_trades_hr_stats import OfferBidTradeGraphStats
 from gsy_e.gsy_e_core.util import (get_feed_in_tariff_rate_from_config,
                                    get_market_maker_rate_from_config)

--- a/src/gsy_e/gsy_e_core/sim_results/file_export_endpoints.py
+++ b/src/gsy_e/gsy_e_core/sim_results/file_export_endpoints.py
@@ -16,21 +16,19 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from abc import ABC, abstractmethod
-from typing import List, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List
 
 from gsy_framework.constants_limits import ConstSettings
-from gsy_framework.enums import BidOfferMatchAlgoEnum, SpotMarketTypeEnum
+from gsy_framework.enums import AvailableMarketTypes, BidOfferMatchAlgoEnum, SpotMarketTypeEnum
 
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 from gsy_e.gsy_e_core.myco_singleton import bid_offer_matcher
 from gsy_e.models.area import Area
 from gsy_e.models.strategy.load_hours import LoadHoursStrategy
 from gsy_e.models.strategy.pv import PVStrategy
-from gsy_e.models.strategy.storage import StorageStrategy
+from gsy_e.models.strategy.scm.load import SCMLoadHoursStrategy, SCMLoadProfileStrategy
 from gsy_e.models.strategy.scm.pv import SCMPVStrategy
-from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy, SCMLoadHoursStrategy
 from gsy_e.models.strategy.scm.storage import SCMStorageStrategy
-
+from gsy_e.models.strategy.storage import StorageStrategy
 
 if TYPE_CHECKING:
     from gsy_e.models.area import CoefficientArea

--- a/src/gsy_e/models/area/__init__.py
+++ b/src/gsy_e/models/area/__init__.py
@@ -16,16 +16,16 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from logging import getLogger
-from typing import List, Dict, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from uuid import uuid4
-from numpy.random import random
 
 from gsy_framework.area_validator import validate_area
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.data_classes import Trade
-from gsy_framework.enums import SpotMarketTypeEnum
+from gsy_framework.enums import AvailableMarketTypes, SpotMarketTypeEnum
 from gsy_framework.exceptions import GSyAreaException, GSyDeviceException
 from gsy_framework.utils import key_in_dict_and_not_none
+from numpy.random import random
 from pendulum import DateTime
 from slugify import slugify
 
@@ -42,9 +42,8 @@ from gsy_e.models.area.redis_external_market_connection import RedisMarketExtern
 from gsy_e.models.area.stats import AreaStats
 from gsy_e.models.area.throughput_parameters import ThroughputParameters
 from gsy_e.models.config import SimulationConfig
-from gsy_e.models.market.future import FutureMarkets
 from gsy_e.models.market.forward import ForwardMarketBase
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
+from gsy_e.models.market.future import FutureMarkets
 from gsy_e.models.strategy import BaseStrategy
 from gsy_e.models.strategy.external_strategies import ExternalMixin
 from gsy_e.models.strategy.scm import SCMStrategy
@@ -52,8 +51,8 @@ from gsy_e.models.strategy.scm import SCMStrategy
 log = getLogger(__name__)
 
 if TYPE_CHECKING:
-    from gsy_e.models.market import MarketBase
     from gsy_e.models.area.scm_manager import SCMManager
+    from gsy_e.models.market import MarketBase
 
 
 def check_area_name_exists_in_parent_area(parent_area, name):

--- a/src/gsy_e/models/area/event_dispatcher.py
+++ b/src/gsy_e/models/area/event_dispatcher.py
@@ -33,7 +33,8 @@ from gsy_e.models.area.redis_dispatcher.market_event_dispatcher import (
 from gsy_e.models.area.redis_dispatcher.market_notify_event_subscriber import (
     MarketNotifyEventSubscriber)
 from gsy_e.models.market import MarketBase
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes, FORWARD_MARKET_TYPES
+from gsy_e.gsy_e_core.enums import FORWARD_MARKET_TYPES
+from gsy_framework.enums import AvailableMarketTypes
 from gsy_e.models.strategy.market_agents.balancing_agent import BalancingAgent
 from gsy_e.models.strategy.market_agents.future_agent import FutureAgent
 from gsy_e.models.strategy.market_agents.one_sided_agent import OneSidedAgent

--- a/src/gsy_e/models/area/markets.py
+++ b/src/gsy_e/models/area/markets.py
@@ -31,7 +31,8 @@ from gsy_e.models.area.market_rotators import (BaseRotator, DefaultMarketRotator
 from gsy_e.models.market import GridFee, MarketBase
 from gsy_e.models.market.balancing import BalancingMarket
 from gsy_e.models.market.future import FutureMarkets
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes, FORWARD_MARKET_TYPES
+from gsy_e.gsy_e_core.enums import FORWARD_MARKET_TYPES
+from gsy_framework.enums import AvailableMarketTypes
 from gsy_e.models.market.one_sided import OneSidedMarket
 from gsy_e.models.market.settlement import SettlementMarket
 from gsy_e.models.market.two_sided import TwoSidedMarket

--- a/src/gsy_e/models/myco_matcher/myco_external_matcher.py
+++ b/src/gsy_e/models/myco_matcher/myco_external_matcher.py
@@ -23,14 +23,14 @@ from typing import Dict, List
 
 from gsy_framework.constants_limits import GlobalConfig
 from gsy_framework.data_classes import BidOfferMatch
+from gsy_framework.enums import AvailableMarketTypes
 
 import gsy_e.constants
 from gsy_e.gsy_e_core.exceptions import InvalidBidOfferPairException, MycoValidationException
-from gsy_e.gsy_e_core.redis_connections.area_market import myco_redis_communicator_factory
 from gsy_e.gsy_e_core.market_counters import ExternalTickCounter
+from gsy_e.gsy_e_core.redis_connections.area_market import myco_redis_communicator_factory
 from gsy_e.models.market.two_sided import TwoSidedMarket
 from gsy_e.models.myco_matcher.myco_matcher_interface import MycoMatcherInterface
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 
 # pylint: disable=fixme
 

--- a/src/gsy_e/models/myco_matcher/myco_internal_matcher.py
+++ b/src/gsy_e/models/myco_matcher/myco_internal_matcher.py
@@ -16,12 +16,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from gsy_framework.constants_limits import ConstSettings
-from gsy_framework.enums import BidOfferMatchAlgoEnum
-from gsy_framework.matching_algorithms import (
-    PayAsBidMatchingAlgorithm, PayAsClearMatchingAlgorithm,
-    AttributedMatchingAlgorithm)
+from gsy_framework.enums import AvailableMarketTypes, BidOfferMatchAlgoEnum
+from gsy_framework.matching_algorithms import (AttributedMatchingAlgorithm,
+                                               PayAsBidMatchingAlgorithm,
+                                               PayAsClearMatchingAlgorithm)
 
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 from gsy_e.gsy_e_core.exceptions import WrongMarketTypeException
 from gsy_e.gsy_e_core.global_objects_singleton import global_objects
 from gsy_e.models.myco_matcher.myco_matcher_interface import MycoMatcherInterface

--- a/src/gsy_e/models/myco_matcher/myco_matcher_forward.py
+++ b/src/gsy_e/models/myco_matcher/myco_matcher_forward.py
@@ -15,10 +15,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from gsy_framework.enums import AvailableMarketTypes
 from gsy_framework.matching_algorithms import (PayAsBidMatchingAlgorithm,
                                                PayAsClearMatchingAlgorithm)
 
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 from gsy_e.gsy_e_core.market_counters import (DayForwardMarketCounter, IntraDayMarketCounter,
                                               MonthForwardMarketCounter, WeekForwardMarketCounter,
                                               YearForwardMarketCounter)

--- a/tests/area/test_area.py
+++ b/tests/area/test_area.py
@@ -16,20 +16,19 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # pylint: disable=missing-function-docstring
-from unittest.mock import MagicMock, patch, Mock, call
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
-from gsy_framework.enums import SpotMarketTypeEnum, BidOfferMatchAlgoEnum
+from gsy_framework.enums import AvailableMarketTypes, BidOfferMatchAlgoEnum, SpotMarketTypeEnum
 from pendulum import duration, today
 
 from gsy_e import constants
-from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.events.event_structures import AreaEvent, MarketEvent
+from gsy_e.gsy_e_core.device_registry import DeviceRegistry
 from gsy_e.models.area import Area, Asset, Market, check_area_name_exists_in_parent_area
 from gsy_e.models.area.events import Events
 from gsy_e.models.config import SimulationConfig
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 from gsy_e.models.strategy.storage import StorageStrategy
 
 

--- a/tests/area/test_event_dispatcher.py
+++ b/tests/area/test_event_dispatcher.py
@@ -21,17 +21,15 @@ from unittest.mock import MagicMock, Mock, call
 
 import pytest
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
-from gsy_framework.enums import SpotMarketTypeEnum
-from pendulum import DateTime, datetime
-from pendulum import duration
+from gsy_framework.enums import AvailableMarketTypes, SpotMarketTypeEnum
+from pendulum import DateTime, datetime, duration
 
-from gsy_e.events.event_structures import MarketEvent, AreaEvent
+from gsy_e.events.event_structures import AreaEvent, MarketEvent
 from gsy_e.models.area import Area
 from gsy_e.models.area.event_dispatcher import AreaDispatcher
 from gsy_e.models.market import MarketBase
 from gsy_e.models.market.balancing import BalancingMarket
 from gsy_e.models.market.future import FutureMarkets
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 from gsy_e.models.market.one_sided import OneSidedMarket
 from gsy_e.models.market.settlement import SettlementMarket
 from gsy_e.models.market.two_sided import TwoSidedMarket
@@ -41,7 +39,6 @@ from gsy_e.models.strategy.market_agents.market_agent import MarketAgent
 from gsy_e.models.strategy.market_agents.one_sided_agent import OneSidedAgent
 from gsy_e.models.strategy.market_agents.settlement_agent import SettlementAgent
 from gsy_e.models.strategy.market_agents.two_sided_agent import TwoSidedAgent
-
 
 # pylint: disable=W0212
 

--- a/tests/area/test_event_dispatcher.py
+++ b/tests/area/test_event_dispatcher.py
@@ -42,6 +42,7 @@ from gsy_e.models.strategy.market_agents.two_sided_agent import TwoSidedAgent
 
 # pylint: disable=W0212
 
+
 @pytest.fixture(name="area_with_markets")
 def area_with_markets_fixture():
     """Return Area activated object that contains all types of markets."""

--- a/tests/market/test_myco_external_matcher.py
+++ b/tests/market/test_myco_external_matcher.py
@@ -3,17 +3,17 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from gsy_framework.enums import AvailableMarketTypes
 from pendulum import now
 
 import gsy_e.constants
-import gsy_e.models.market.market_redis_connection
-from gsy_e.gsy_e_core.exceptions import MycoValidationException, InvalidBidOfferPairException
 import gsy_e.gsy_e_core.redis_connections.area_market
-from gsy_e.models.market import Offer, Bid
+import gsy_e.models.market.market_redis_connection
+from gsy_e.gsy_e_core.exceptions import InvalidBidOfferPairException, MycoValidationException
+from gsy_e.models.market import Bid, Offer
 from gsy_e.models.market.two_sided import TwoSidedMarket
 from gsy_e.models.myco_matcher import MycoExternalMatcher
 from gsy_e.models.myco_matcher.myco_external_matcher import MycoExternalMatcherValidator
-from gsy_e.gsy_e_core.enums import AvailableMarketTypes
 
 gsy_e.gsy_e_core.redis_connections.area_market.ResettableCommunicator = MagicMock
 


### PR DESCRIPTION
## Reason for the proposed changes

Move `AvailableMarketTypes`' definition to gsy-framework as this class is going to be used in other repos as well.

## Proposed changes
 
- Move `AvailableMarketTypes`' definition to gsy-framework

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=feature/GSYE-375
