### PR TITLE
GSYE-373-3: Add unit tests for _read_forward_markets_stats_to_dict

### DIFF
--- a/tests/test_endpoint_buffers.py
+++ b/tests/test_endpoint_buffers.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock
+
+import pytest
+from gsy_framework.constants_limits import ConstSettings
+from pendulum import DateTime, duration
+
+from gsy_e.gsy_e_core.enums import FORWARD_MARKET_TYPES
+from gsy_e.gsy_e_core.sim_results.endpoint_buffer import SimulationEndpointBuffer
+
+
+@pytest.fixture(name="forward_setup")
+def forward_setup_fixture():
+    """Create area with all the forward markets and
+    pre added timeslots for each forward market."""
+    ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS = True
+    slot_length = duration(minutes=15)
+    area = MagicMock(forward_markets={
+        # each forward market will have 5 timeslots.
+        market_type: MagicMock(market_time_slots=[
+            f"TIME_SLOT_{i}" for i in range(5)
+        ]) for market_type in FORWARD_MARKET_TYPES
+    }, config=MagicMock(slot_length=slot_length), uuid="AREA")
+    yield area, slot_length
+    ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS = False
+
+
+class TestSimulationEndpointBuffer:
+
+    @staticmethod
+    def gen_order(creation_time, time_slot):
+        """Generate one mock order{bid,offer,trade}."""
+        return MagicMock(
+            creation_time=creation_time,
+            time_slot=time_slot,
+            serializable_dict=lambda: {
+                "creation_time": creation_time, "time_slot": time_slot})
+
+    def test_forward_results_are_generated(   # pylint: disable-msg=too-many-locals
+            self, forward_setup):
+        """Test results are being correctly generated with respect to
+        forward market timeslots and current market timeslot."""
+        area, slot_length = forward_setup
+
+        progress_info = MagicMock()
+        epb = SimulationEndpointBuffer("JOB_1", 41, area, False)
+
+        # add bids/offers/trades for 3 consequent slots for all forward timeslots.
+        start_time = DateTime(2020, 1, 1, 0, 15)
+        for market in area.forward_markets.values():
+            current_time = start_time
+
+            market.bid_history = []
+            market.offer_history = []
+            market.trades = []
+
+            for _ in range(3):
+                market.bid_history.extend([
+                    self.gen_order(
+                        creation_time=current_time - slot_length,
+                        time_slot=f"TIME_SLOT_{i}") for i in range(5)])
+                market.offer_history.extend([
+                    self.gen_order(
+                        creation_time=current_time - slot_length,
+                        time_slot=f"TIME_SLOT_{i}") for i in range(5)])
+                market.trades.extend([
+                    self.gen_order(
+                        creation_time=current_time - slot_length,
+                        time_slot=f"TIME_SLOT_{i}") for i in range(5)])
+                current_time += slot_length
+
+        # update the endpoint buffer for each of the 3 timeslots and
+        # check results are generated correctly.
+        current_time = start_time
+        for _ in range(3):
+            area.now = current_time
+            epb.update_stats(area, "running", progress_info, {}, False)
+            raw_results = epb.generate_result_report()["simulation_raw_data"]
+            area_forward_stats = raw_results[area.uuid]["forward_market_stats"]
+
+            for market_type in FORWARD_MARKET_TYPES:
+                market_stats = area_forward_stats[market_type.value]
+                for i in range(5):
+                    timeslot_stats = market_stats[f"TIME_SLOT_{i}"]
+                    for order_type in ("bids", "offers", "trades"):
+                        orders = timeslot_stats[order_type]
+                        assert len(orders) == 1
+                        assert orders[0]["time_slot"] == f"TIME_SLOT_{i}"
+                        assert (current_time - slot_length <=
+                                orders[0]["creation_time"] < current_time)
+            current_time += slot_length

--- a/tests/test_endpoint_buffers.py
+++ b/tests/test_endpoint_buffers.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from gsy_framework.constants_limits import ConstSettings
+from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from pendulum import DateTime, duration
 
 from gsy_e.gsy_e_core.enums import FORWARD_MARKET_TYPES
@@ -12,6 +12,7 @@ from gsy_e.gsy_e_core.sim_results.endpoint_buffer import SimulationEndpointBuffe
 def forward_setup_fixture():
     """Create area with all the forward markets and
     pre added timeslots for each forward market."""
+    GlobalConfig.market_maker_rate = 30
     ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS = True
     slot_length = duration(minutes=15)
     area = MagicMock(forward_markets={

--- a/tests/test_endpoint_buffers.py
+++ b/tests/test_endpoint_buffers.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
@@ -50,19 +51,21 @@ class TestSimulationEndpointBuffer:
         for market in area.forward_markets.values():
             current_time = start_time
 
-            market.bid_history = []
-            market.offer_history = []
+            market.bids = {}
+            market.offers = {}
             market.trades = []
 
             for _ in range(3):
-                market.bid_history.extend([
-                    self.gen_order(
+
+                for i in range(5):
+                    market.bids[uuid4()] = self.gen_order(
                         creation_time=current_time - slot_length,
-                        time_slot=f"TIME_SLOT_{i}") for i in range(5)])
-                market.offer_history.extend([
-                    self.gen_order(
+                        time_slot=f"TIME_SLOT_{i}")
+
+                    market.offers[uuid4()] = self.gen_order(
                         creation_time=current_time - slot_length,
-                        time_slot=f"TIME_SLOT_{i}") for i in range(5)])
+                        time_slot=f"TIME_SLOT_{i}")
+
                 market.trades.extend([
                     self.gen_order(
                         creation_time=current_time - slot_length,


### PR DESCRIPTION
## Reason for the proposed changes
As requests by [GSYE-373](https://gridsingularity.atlassian.net/browse/GSYE-373) and asked by @fievelk.

## Proposed changes
- Add unit test for checking functionality of SimulationEndpointBuffer while generating forward market stats.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
