### PR TITLE
GSYE-386: Only export open and unmatched bids/offers of forward markets

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, Iterable, List
 
 from gsy_framework.constants_limits import (DATE_TIME_FORMAT, DATE_TIME_UI_FORMAT, ConstSettings,
                                             GlobalConfig)
@@ -168,7 +168,7 @@ class SimulationEndpointBuffer:
 
     @staticmethod
     def _get_current_forward_orders_from_timeslot(
-            forward_orders: List,
+            forward_orders: Iterable,
             market_time_slot: DateTime,
             area: "Area") -> List:
         """Filter orders that have happened in the current simulation time for
@@ -219,10 +219,11 @@ class SimulationEndpointBuffer:
             for time_slot in market.market_time_slots:
                 time_slot_str = time_slot.format(DATE_TIME_FORMAT)
                 stats_dict[market_type.value][time_slot_str] = {
+                    # only export unmatched open bids/offers
                     "bids": self._get_current_forward_orders_from_timeslot(
-                        market.bid_history, time_slot, area),
+                        market.bids.values(), time_slot, area),
                     "offers": self._get_current_forward_orders_from_timeslot(
-                        market.offer_history, time_slot, area),
+                        market.offers.values(), time_slot, area),
                     "trades": self._get_current_forward_orders_from_timeslot(
                         market.trades, time_slot, area),
                     "market_fee": market.market_fee,


### PR DESCRIPTION
## Reason for the proposed changes
This PR is related to https://github.com/gridsingularity/gsy-framework/pull/388. For forward markets we need to only export open and unmatched bids/offers to the ResultsAggregator.

## Proposed changes

- Only export open and unmatched bids/offers of forward markets

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
