### PR TITLE
Refactor decrement energy to always delegate actions to energy params class

### DIFF
--- a/src/gsy_e/models/strategy/energy_parameters/load.py
+++ b/src/gsy_e/models/strategy/energy_parameters/load.py
@@ -53,6 +53,13 @@ class LoadHoursEnergyParameters:
         """Return dict with the current energy parameter values."""
         return {"avg_power_W": self.avg_power_W, "hrs_of_day": self.hrs_of_day}
 
+    def decrement_energy_requirement(self, energy_kWh: float, time_slot: DateTime, area_name: str):
+        """Decrease the energy requirements of the asset."""
+        self.state.decrement_energy_requirement(
+            purchased_energy_Wh=energy_kWh * 1000,
+            time_slot=time_slot,
+            area_name=area_name)
+
     def set_energy_measurement_kWh(self, time_slot: DateTime) -> None:
         """Set the (simulated) actual energy consumed by the device in a market slot."""
         energy_forecast_kWh = self.state.get_desired_energy_Wh(time_slot) / 1000

--- a/src/gsy_e/models/strategy/energy_parameters/smart_meter.py
+++ b/src/gsy_e/models/strategy/energy_parameters/smart_meter.py
@@ -38,6 +38,13 @@ class SmartMeterEnergyParameters:
         self._energy_profile.read_or_rotate_profiles()
         self._simulation_start_timestamp = area.now
 
+    def decrement_energy_requirement(self, energy_kWh: float, time_slot: DateTime, area_name: str):
+        """Decrease the energy requirements of the asset."""
+        self._state.decrement_energy_requirement(
+            purchased_energy_Wh=energy_kWh * 1000,
+            time_slot=time_slot,
+            area_name=area_name)
+
     def set_energy_forecast_for_future_markets(self, time_slots, reconfigure: bool = True):
         """Set the energy consumption/production expectations for the upcoming market slots.
 

--- a/src/gsy_e/models/strategy/load_hours.py
+++ b/src/gsy_e/models/strategy/load_hours.py
@@ -308,7 +308,11 @@ class LoadHoursStrategy(BidEnabledStrategy):
                                   buyer_origin=self.owner.name,
                                   buyer_origin_id=self.owner.uuid,
                                   buyer_id=self.owner.uuid)
-                self.state.decrement_energy_requirement(energy_Wh, time_slot, self.owner.name)
+
+                self._energy_params.decrement_energy_requirement(
+                    energy_kWh=energy_Wh / 1000,
+                    time_slot=time_slot,
+                    area_name=self.owner.name)
                 self._energy_params.decrease_hours_per_day(time_slot, energy_Wh)
 
         except MarketException:
@@ -389,11 +393,13 @@ class LoadHoursStrategy(BidEnabledStrategy):
         if not self.area.is_market_spot_or_future(market_id):
             return
         if bid_trade.offer_bid.buyer == self.owner.name:
-            self.state.decrement_energy_requirement(
-                bid_trade.traded_energy * 1000,
-                bid_trade.time_slot, self.owner.name)
-            self._energy_params.decrease_hours_per_day(bid_trade.time_slot,
-                                                       bid_trade.traded_energy * 1000.0)
+            self._energy_params.decrement_energy_requirement(
+                energy_kWh=bid_trade.traded_energy,
+                time_slot=bid_trade.time_slot,
+                area_name=self.owner.name)
+            self._energy_params.decrease_hours_per_day(
+                bid_trade.time_slot,
+                bid_trade.traded_energy * 1000.0)
 
     def event_offer_traded(self, *, market_id, trade):
         """Register the offer traded by the device and its effects. Extends the superclass method.
@@ -421,7 +427,12 @@ class LoadHoursStrategy(BidEnabledStrategy):
 
         ramp_up_energy = (self.balancing_energy_ratio.demand *
                           self.state.get_desired_energy_Wh(market.time_slot))
-        self.state.decrement_energy_requirement(ramp_up_energy, market.time_slot, self.owner.name)
+
+        self._energy_params.decrement_energy_requirement(
+            energy_kWh=ramp_up_energy / 1000,
+            time_slot=market.time_slot,
+            area_name=self.owner.name)
+
         ramp_up_price = DeviceRegistry.REGISTRY[self.owner.name][0] * ramp_up_energy
         if ramp_up_energy != 0 and ramp_up_price != 0:
             self.area.get_balancing_market(market.time_slot).balancing_offer(

--- a/src/gsy_e/models/strategy/scm/load.py
+++ b/src/gsy_e/models/strategy/scm/load.py
@@ -53,8 +53,11 @@ class SCMLoadHoursStrategy(SCMStrategy):
 
     def decrease_energy_to_buy(
             self, traded_energy_kWh: float, time_slot: DateTime, area: "AreaBase") -> None:
-        self._energy_params.state.decrement_energy_requirement(
-            traded_energy_kWh, time_slot, area.name)
+        """Decrease the energy requirements of the asset."""
+        self._energy_params.decrement_energy_requirement(
+            energy_kWh=traded_energy_kWh,
+            time_slot=time_slot,
+            area_name=area.name)
 
 
 class SCMLoadProfileStrategy(SCMStrategy):
@@ -87,9 +90,11 @@ class SCMLoadProfileStrategy(SCMStrategy):
 
     def decrease_energy_to_buy(
             self, traded_energy_kWh: float, time_slot: DateTime, area: "AreaBase") -> None:
-        """Decrease traded energy from the state and the strategy parameters."""
-        self._energy_params.state.decrement_energy_requirement(
-            traded_energy_kWh, time_slot, area.name)
+        """Decrease the amount of traded energy from the asset's state."""
+        self._energy_params.decrement_energy_requirement(
+            energy_kWh=traded_energy_kWh,
+            time_slot=time_slot,
+            area_name=area.name)
 
     def get_energy_to_buy_kWh(self, time_slot: DateTime) -> float:
         """Get the available energy for consumption for the specified time slot."""

--- a/src/gsy_e/models/strategy/scm/smart_meter.py
+++ b/src/gsy_e/models/strategy/scm/smart_meter.py
@@ -53,12 +53,12 @@ class SCMSmartMeterStrategy(SCMStrategy):
     def decrease_energy_to_sell(
             self, traded_energy_kWh: float, time_slot: DateTime, area: "CoefficientArea"):
         """Decrease traded energy from the state and the strategy parameters."""
-        self._energy_params.decrement_energy_requirement(
-            energy_kWh=traded_energy_kWh,
-            time_slot=time_slot,
-            area_name=area.name)
+        self.state.decrement_available_energy(traded_energy_kWh, time_slot, area.name)
 
     def decrease_energy_to_buy(
             self, traded_energy_kWh: float, time_slot: DateTime, area: "CoefficientArea"):
         """Decrease traded energy from the state and the strategy parameters."""
-        self.state.decrement_available_energy(traded_energy_kWh, time_slot, area.name)
+        self._energy_params.decrement_energy_requirement(
+            energy_kWh=traded_energy_kWh,
+            time_slot=time_slot,
+            area_name=area.name)

--- a/src/gsy_e/models/strategy/scm/smart_meter.py
+++ b/src/gsy_e/models/strategy/scm/smart_meter.py
@@ -53,7 +53,10 @@ class SCMSmartMeterStrategy(SCMStrategy):
     def decrease_energy_to_sell(
             self, traded_energy_kWh: float, time_slot: DateTime, area: "CoefficientArea"):
         """Decrease traded energy from the state and the strategy parameters."""
-        self.state.decrement_energy_requirement(traded_energy_kWh, time_slot, area.name)
+        self._energy_params.decrement_energy_requirement(
+            energy_kWh=traded_energy_kWh,
+            time_slot=time_slot,
+            area_name=area.name)
 
     def decrease_energy_to_buy(
             self, traded_energy_kWh: float, time_slot: DateTime, area: "CoefficientArea"):

--- a/src/gsy_e/models/strategy/smart_meter.py
+++ b/src/gsy_e/models/strategy/smart_meter.py
@@ -249,8 +249,10 @@ class SmartMeterStrategy(BidEnabledStrategy):
         super().event_bid_traded(market_id=market_id, bid_trade=bid_trade)
 
         market = self.area.get_spot_or_future_market_by_id(market_id)
-        self.state.decrement_energy_requirement(
-            bid_trade.traded_energy * 1000, market.time_slot, self.owner.name)
+        self._energy_params.decrement_energy_requirement(
+            energy_kWh=bid_trade.traded_energy,
+            time_slot=market.time_slot,
+            area_name=self.owner.name)
 
     def area_reconfigure_event(self, *args, **kwargs):
         """Reconfigure the device properties at runtime using the provided arguments.
@@ -511,7 +513,11 @@ class SmartMeterStrategy(BidEnabledStrategy):
                                   buyer_origin=self.owner.name,
                                   buyer_origin_id=self.owner.uuid,
                                   buyer_id=self.owner.uuid)
-                self.state.decrement_energy_requirement(energy_Wh, time_slot, self.owner.name)
+
+                self._energy_params.decrement_energy_requirement(
+                    energy_kWh=energy_Wh / 1000,
+                    time_slot=time_slot,
+                    area_name=self.owner.name)
 
         except MarketException:
             self.log.exception("An Error occurred while buying an offer.")


### PR DESCRIPTION
## Reason for the proposed changes

The `decrement_energy_requirement()` method is currently called by the strategy directly on the `state` instance. This is not optimal: all interactions with energy parameters should be delegated to the `*EnergyParameters` classes (which will in turn call the state's methods).

**Update:** this PR also contains two bugfixes for SCM smart meters (when buying/selling energy).

## Proposed changes

- Implement `decrement_energy_requirement()` method on the energy parameter classes (for consumption devices)
- In the strategy classes, replace the calls made to `state.decrement_energy_requirement()` with `energy_params.decrement_energy_requirement()`

---

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
