### PR TITLE
GSYE-388-2: Fix SCM time-related failures

### DIFF
--- a/src/gsy_e/gsy_e_core/simulation/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation/simulation.py
@@ -152,6 +152,8 @@ class Simulation:
             if self._setup.started_from_cli:
                 self._run_cli_execute_cycle(initial_slot, tick_resume)
             else:
+                # update status of the simulation before executing it.
+                self._results.update_and_send_results(simulation=self)
                 self._execute_simulation(initial_slot, tick_resume)
         except (KeyboardInterrupt, SimulationResetException):
             pass

--- a/src/gsy_e/gsy_e_core/simulation/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation/simulation.py
@@ -419,6 +419,8 @@ class CoefficientSimulation(Simulation):
             self._time.calc_resume_slot_and_count_realtime(
                 self.config, slot_resume))
 
+        self._time.reset(not_restored_from_state=(slot_resume == 0))
+
         for slot_no in range(slot_resume, slot_count):
             self._handle_paused(console)
 

--- a/src/gsy_e/gsy_e_core/simulation/time_manager.py
+++ b/src/gsy_e/gsy_e_core/simulation/time_manager.py
@@ -155,11 +155,10 @@ class SimulationTimeManagerScm:
             log.debug("Slot %s/%s: Sleep time of %s s was applied",
                       slot_no, slot_count, sleep_time_s)
 
-        self.slot_time_counter = time()
+        self.slot_time_counter = int(time())
 
-    @staticmethod
     def calc_resume_slot_and_count_realtime(
-            config: "SimulationConfig", slot_resume: int) -> Tuple[int, int]:
+            self, config: "SimulationConfig", slot_resume: int) -> Tuple[int, int]:
         """Calculate total slot count and the slot where to resume the realtime simulation."""
         slot_count = int(config.sim_duration / config.slot_length)
 
@@ -173,6 +172,7 @@ class SimulationTimeManagerScm:
             sleep_time_s = config.slot_length.total_seconds() - seconds_elapsed_in_slot
             sleep(sleep_time_s)
 
+        self.slot_time_counter = int(time())
         return slot_count, slot_resume
 
 

--- a/src/gsy_e/gsy_e_core/simulation/time_manager.py
+++ b/src/gsy_e/gsy_e_core/simulation/time_manager.py
@@ -155,7 +155,7 @@ class SimulationTimeManagerScm:
             log.debug("Slot %s/%s: Sleep time of %s s was applied",
                       slot_no, slot_count, sleep_time_s)
 
-        self.reset(not_restored_from_state=False)
+        self.slot_time_counter = int(time())
 
     def calc_resume_slot_and_count_realtime(
             self, config: "SimulationConfig", slot_resume: int) -> Tuple[int, int]:
@@ -172,7 +172,6 @@ class SimulationTimeManagerScm:
             sleep_time_s = config.slot_length.total_seconds() - seconds_elapsed_in_slot
             sleep(sleep_time_s)
 
-        self.reset(not_restored_from_state=False)
         return slot_count, slot_resume
 
 

--- a/src/gsy_e/gsy_e_core/simulation/time_manager.py
+++ b/src/gsy_e/gsy_e_core/simulation/time_manager.py
@@ -127,7 +127,7 @@ class SimulationTimeManagerScm:
         Restore time-related parameters of the simulation to their default values.
         Mainly useful when resetting the simulation.
         """
-        self.slot_time_counter = time()
+        self.slot_time_counter = int(time())
         if not_restored_from_state:
             self.start_time = now(tz=TIME_ZONE)
             self.paused_time = 0
@@ -145,8 +145,8 @@ class SimulationTimeManagerScm:
             slot_runtime_s = time() - self.slot_time_counter
             sleep_time_s = config.slot_length.total_seconds() - slot_runtime_s
         elif slot_length_realtime_s:
-            current_expected_tick_time = self.slot_time_counter + slot_length_realtime_s
-            sleep_time_s = current_expected_tick_time - now().timestamp()
+            current_expected_slot_time = self.slot_time_counter + slot_length_realtime_s
+            sleep_time_s = current_expected_slot_time - now().timestamp()
         else:
             return
 
@@ -155,7 +155,7 @@ class SimulationTimeManagerScm:
             log.debug("Slot %s/%s: Sleep time of %s s was applied",
                       slot_no, slot_count, sleep_time_s)
 
-        self.slot_time_counter = int(time())
+        self.reset(not_restored_from_state=False)
 
     def calc_resume_slot_and_count_realtime(
             self, config: "SimulationConfig", slot_resume: int) -> Tuple[int, int]:
@@ -172,7 +172,7 @@ class SimulationTimeManagerScm:
             sleep_time_s = config.slot_length.total_seconds() - seconds_elapsed_in_slot
             sleep(sleep_time_s)
 
-        self.slot_time_counter = int(time())
+        self.reset(not_restored_from_state=False)
         return slot_count, slot_resume
 
 


### PR DESCRIPTION
*NOTE: The duplicated key exception was never spotted again after Hannes' fix. This PR resolves only some other minor issues.*

## Reason for the proposed changes
- `slot_time_counter` increases irregularly because of accumulated miliseconds.
- Status of simulation is not set to "running" before the initial sleep of `calculate_total_initial_ticks_slots`.

### Before this PR:
```
slot_no start_of_slot
506 2022-10-07T16:52:00.022406+02:00
507 2022-10-07T16:53:35.357447+02:00
508 2022-10-07T16:55:35.457563+02:00
509 2022-10-07T16:57:35.557277+02:00
510 2022-10-07T16:59:35.657843+02:00
511 2022-10-07T17:01:35.741415+02:00
512 2022-10-07T17:03:35.840907+02:00
513 2022-10-07T17:05:35.942096+02:00
514 2022-10-07T17:07:36.042252+02:00
515 2022-10-07T17:09:36.140363+02:00
516 2022-10-07T17:11:36.223580+02:00
517 2022-10-07T17:13:36.297965+02:00
518 2022-10-07T17:15:36.398065+02:00
...
```

### After this PR:
```
slot_no start_of_slot
538 2022-10-07T17:56:00.097372+02:00
539 2022-10-07T17:58:00.098123+02:00
540 2022-10-07T18:00:00.100255+02:00
541 2022-10-07T18:02:00.100579+02:00
542 2022-10-07T18:04:00.097163+02:00
543 2022-10-07T18:06:00.097132+02:00
544 2022-10-07T18:08:00.097409+02:00
545 2022-10-07T18:10:00.097453+02:00
546 2022-10-07T18:12:00.100899+02:00
547 2022-10-07T18:14:00.097614+02:00
548 2022-10-07T18:16:00.097326+02:00
...
```

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=bug/GSYE-388
**GSY_FRAMEWORK_BRANCH**=master
