### PR TITLE
GSYE-417: Add raise of exception when profile in DB is empty.

### DIFF
--- a/src/gsy_e/gsy_e_core/user_profile_handler.py
+++ b/src/gsy_e/gsy_e_core/user_profile_handler.py
@@ -32,6 +32,10 @@ import gsy_e.constants
 from gsy_e.gsy_e_core.util import should_read_profile_from_db
 
 
+class ProfileDBConnectionException(Exception):
+    """Exception that is raised inside ProfileDBConnectionHandler."""
+
+
 class ProfileDBConnectionHandler:
     """
     Handles connection and interaction with the user-profiles postgres DB via pony ORM
@@ -98,10 +102,13 @@ class ProfileDBConnectionHandler:
         """
         if not isinstance(profile_uuid, uuid.UUID):
             profile_uuid = uuid.UUID(profile_uuid)
-        first_datapoint_time = select(
+        first_datapoint = select(
             datapoint for datapoint in self.Profile_Database_ProfileTimeSeries
             if datapoint.profile_uuid == profile_uuid
-        ).order_by(lambda d: d.time).limit(1)[0].time
+        ).order_by(lambda d: d.time).limit(1)
+        if len(first_datapoint) == 0:
+            raise ProfileDBConnectionException("Profile in DB is empty.")
+        first_datapoint_time = first_datapoint[0].time
 
         datapoints = select(
             datapoint for datapoint in self.Profile_Database_ProfileTimeSeries

--- a/src/gsy_e/gsy_e_core/user_profile_handler.py
+++ b/src/gsy_e/gsy_e_core/user_profile_handler.py
@@ -107,7 +107,8 @@ class ProfileDBConnectionHandler:
             if datapoint.profile_uuid == profile_uuid
         ).order_by(lambda d: d.time).limit(1)
         if len(first_datapoint) == 0:
-            raise ProfileDBConnectionException("Profile in DB is empty.")
+            raise ProfileDBConnectionException(
+                f"Profile in DB is empty for profile with uuid {profile_uuid}")
         first_datapoint_time = first_datapoint[0].time
 
         datapoints = select(


### PR DESCRIPTION
## Reason for the proposed changes

If there is an empty profile in the DB, the code will fail with an IndexError that is not very understandable.

## Proposed changes

Add a custom exception that is raised if there is an empty profile in the DB that is about to be read. 


<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
