### PR TITLE
GSYE-431: Adapt scm strategies to also have profile uuids as memebers…

### DIFF
--- a/src/gsy_e/gsy_e_core/simulation/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation/simulation.py
@@ -398,6 +398,10 @@ class CoefficientSimulation(Simulation):
 
         self.area = self._setup.load_setup_module()
 
+        # has to be called after areas are initiated in order to retrieve the profile uuids
+        global_objects.profiles_handler.update_time_and_buffer_profiles(
+            GlobalConfig.start_date, area=self.area)
+
         self._results.init_results(self.simulation_id, self.area, self._setup)
         self._results.update_and_send_results(self)
 

--- a/src/gsy_e/models/strategy/scm/load.py
+++ b/src/gsy_e/models/strategy/scm/load.py
@@ -65,6 +65,7 @@ class SCMLoadProfileStrategy(SCMStrategy):
     def __init__(self, daily_load_profile=None, daily_load_profile_uuid=None):
         self._energy_params = DefinedLoadEnergyParameters(
             daily_load_profile, daily_load_profile_uuid)
+        self.daily_load_profile_uuid = daily_load_profile_uuid
 
     @property
     def state(self):

--- a/src/gsy_e/models/strategy/scm/pv.py
+++ b/src/gsy_e/models/strategy/scm/pv.py
@@ -63,6 +63,7 @@ class SCMPVUserProfile(SCMPVStrategy):
                  power_profile_uuid: str = None):
         self._energy_params = PVUserProfileEnergyParameters(1, power_profile, power_profile_uuid)
         super().__init__()
+        self.power_profile_uuid = power_profile_uuid
 
     def _update_forecast_in_state(self, area):
         self._energy_params.read_predefined_profile_for_pv()

--- a/src/gsy_e/models/strategy/scm/smart_meter.py
+++ b/src/gsy_e/models/strategy/scm/smart_meter.py
@@ -19,6 +19,7 @@ class SCMSmartMeterStrategy(SCMStrategy):
             smart_meter_profile_uuid: str = None):
         self._energy_params = SmartMeterEnergyParameters(
             smart_meter_profile, smart_meter_profile_uuid)
+        self.smart_meter_profile_uuid = smart_meter_profile_uuid
 
     @property
     def state(self) -> "SmartMeterState":


### PR DESCRIPTION
… in order for the profile handler to retrieve the used profiles before buffering them

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
