### PR TITLE
GSYE-446: Export capacity_kW in area_dict for forward markets

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -162,6 +162,10 @@ class SimulationEndpointBuffer:
         area_dict["type"] = (str(target_area.strategy.__class__.__name__)
                              if target_area.strategy is not None else "Area")
         area_dict["children"] = []
+
+        if ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS:
+            area_dict["capacity_kWh"] = target_area.strategy.capacity_kW
+
         return area_dict
 
     def _create_area_tree_dict(self, area: "AreaBase") -> Dict:
@@ -372,7 +376,7 @@ class CoefficientEndpointBuffer(SimulationEndpointBuffer):
     def _create_endpoint_buffer(self, should_export_plots):
         return ResultsHandler(should_export_plots, is_scm=True)
 
-    def update_coefficient_stats(
+    def update_coefficient_stats(  # pylint: disable=too-many-arguments
             self, area: "AreaBase", simulation_status: str,
             progress_info: "SimulationProgressInfo", sim_state: Dict,
             calculate_results: bool, scm_manager: "SCMManager") -> None:

--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -165,7 +165,7 @@ class SimulationEndpointBuffer:
 
         if (ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS and
                 target_area.strategy is not None):
-            area_dict["capacity_kWh"] = target_area.strategy.capacity_kWh
+            area_dict["capacity_kW"] = target_area.strategy._energy_params.capacity_kW
 
         return area_dict
 

--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -163,8 +163,9 @@ class SimulationEndpointBuffer:
                              if target_area.strategy is not None else "Area")
         area_dict["children"] = []
 
-        if ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS:
-            area_dict["capacity_kWh"] = target_area.strategy.capacity_kW
+        if (ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS and
+                target_area.strategy is not None):
+            area_dict["capacity_kWh"] = target_area.strategy.capacity_kWh
 
         return area_dict
 

--- a/tests/test_endpoint_buffers.py
+++ b/tests/test_endpoint_buffers.py
@@ -27,7 +27,8 @@ def forward_setup_fixture():
     area = MagicMock(
         forward_markets=forward_markets,
         config=MagicMock(slot_length=slot_length),
-        uuid="AREA")
+        uuid="AREA",
+        strategy=None)
     area.name = "area-name"
     area.parent = None
 
@@ -135,7 +136,7 @@ class TestSimulationEndpointBuffer:
                 "name": "area-name",
                 "uuid": "AREA",
                 "parent_uuid": "",
-                "type": "MagicMock",
+                "type": "Area",
                 "children": []
             }
         }
@@ -203,7 +204,6 @@ class TestSimulationEndpointBuffer:
         child_2.parent = area
 
         area.children = [child_1, child_2]
-        area.strategy = None
 
         endpoint_buffer = SimulationEndpointBuffer(
             job_id="JOB_1",

--- a/tests/test_endpoint_buffers.py
+++ b/tests/test_endpoint_buffers.py
@@ -196,11 +196,11 @@ class TestSimulationEndpointBuffer:
         # Popoulate strategy and children to update the result_area_uuids dictionary
         child_1 = MagicMock(uuid="child-uuid-1")
         child_1.name = "child_1"
-        child_1.strategy = MagicMock(capacity_kWh=2)
+        child_1.strategy = MagicMock(_energy_params=MagicMock(capacity_kW=2))
         child_1.parent = area
         child_2 = MagicMock(uuid="child-uuid-2")
         child_2.name = "child_2"
-        child_2.strategy = MagicMock(capacity_kWh=1.5)
+        child_2.strategy = MagicMock(_energy_params=MagicMock(capacity_kW=1.5))
         child_2.parent = area
 
         area.children = [child_1, child_2]
@@ -242,7 +242,7 @@ class TestSimulationEndpointBuffer:
                     "parent_uuid": "AREA",
                     "type": "MagicMock",
                     "uuid": "child-uuid-1",
-                    "capacity_kWh": child_1.strategy.capacity_kWh
+                    "capacity_kW": 2
                 },
                 {
                     "children": [],
@@ -250,7 +250,7 @@ class TestSimulationEndpointBuffer:
                     "parent_uuid": "AREA",
                     "type": "MagicMock",
                     "uuid": "child-uuid-2",
-                    "capacity_kWh": child_2.strategy.capacity_kWh
+                    "capacity_kW": 1.5
                 },
             ],
         }

--- a/tests/test_endpoint_buffers.py
+++ b/tests/test_endpoint_buffers.py
@@ -195,13 +195,15 @@ class TestSimulationEndpointBuffer:
         # Popoulate strategy and children to update the result_area_uuids dictionary
         child_1 = MagicMock(uuid="child-uuid-1")
         child_1.name = "child_1"
+        child_1.strategy = MagicMock(capacity_kWh=2)
         child_1.parent = area
         child_2 = MagicMock(uuid="child-uuid-2")
         child_2.name = "child_2"
+        child_2.strategy = MagicMock(capacity_kWh=1.5)
         child_2.parent = area
 
         area.children = [child_1, child_2]
-        area.strategy = MagicMock(name="some-strategy")
+        area.strategy = None
 
         endpoint_buffer = SimulationEndpointBuffer(
             job_id="JOB_1",
@@ -232,7 +234,7 @@ class TestSimulationEndpointBuffer:
             "name": "area-name",
             "uuid": "AREA",
             "parent_uuid": "",
-            "type": "MagicMock",
+            "type": "Area",
             "children": [
                 {
                     "children": [],
@@ -240,6 +242,7 @@ class TestSimulationEndpointBuffer:
                     "parent_uuid": "AREA",
                     "type": "MagicMock",
                     "uuid": "child-uuid-1",
+                    "capacity_kWh": child_1.strategy.capacity_kWh
                 },
                 {
                     "children": [],
@@ -247,6 +250,7 @@ class TestSimulationEndpointBuffer:
                     "parent_uuid": "AREA",
                     "type": "MagicMock",
                     "uuid": "child-uuid-2",
+                    "capacity_kWh": child_2.strategy.capacity_kWh
                 },
             ],
         }

--- a/tests/test_endpoint_buffers.py
+++ b/tests/test_endpoint_buffers.py
@@ -185,7 +185,7 @@ class TestSimulationEndpointBuffer:
             "mocked-results": "some-results"
         }
 
-    def test_update_stats(self, forward_setup):
+    def test_update_stats_forward_markets(self, forward_setup):
         # pylint: disable=protected-access
         area, _ = forward_setup
         area.current_market = MagicMock(


### PR DESCRIPTION
## Reason for the proposed changes
As requested by GSYE-446, we want to calculate and store asset volume time series for forward markets.
capacity_kW is needed to generate the scaled ssp profile of the volume time series.

## Proposed changes
- Add `capacity_kW` to exported kafka results for forward markets.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
