### PR TITLE
GSYE-450: Pass daily_load_profile_uuid to super class in LoadProfileF…

### DIFF
--- a/src/gsy_e/models/strategy/external_strategies/load.py
+++ b/src/gsy_e/models/strategy/external_strategies/load.py
@@ -457,7 +457,9 @@ class LoadProfileForecastExternalStrategy(
                          final_buying_rate=final_buying_rate,
                          initial_buying_rate=initial_buying_rate,
                          balancing_energy_ratio=balancing_energy_ratio,
-                         use_market_maker_rate=use_market_maker_rate)
+                         use_market_maker_rate=use_market_maker_rate,
+                         daily_load_profile_uuid=daily_load_profile_uuid,
+                         )
 
         self._energy_params = LoadProfileForecastEnergyParams(
             daily_load_profile, daily_load_profile_uuid)


### PR DESCRIPTION
…orecastExternalStrategy in order to be saved as attribute to the class and read by the profile handler

## Reason for the proposed changes

In CNs profiles where not buffered by the profiles handler because it was not aware of the profiles that were used by the `LoadProfileForecastExternalStrategy` . This Strategy is automatically selected, because `forecast_stream_enabled=True` is default for al CN assets.  

## Proposed changes

The fix was easy. We need to pass the `daily_load_profile_uuid` to the super class `DefinedLoadStrategy` that is saving it as an class attribute to be read by `ProfilesHandler._get_profile_uuids_from_setup`.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
