### PR TITLE
GSYE-427-pre: Move OrderUpdater out of forward package in order to be…

### DIFF
--- a/src/gsy_e/models/area/area.py
+++ b/src/gsy_e/models/area/area.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from logging import getLogger
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from gsy_framework.area_validator import validate_area
 from gsy_framework.constants_limits import ConstSettings
@@ -41,13 +41,15 @@ from gsy_e.models.area.throughput_parameters import ThroughputParameters
 from gsy_e.models.config import SimulationConfig
 from gsy_e.models.market.forward import ForwardMarketBase
 from gsy_e.models.market.future import FutureMarkets
-from gsy_e.models.strategy import BaseStrategy
+
 from gsy_e.models.strategy.external_strategies import ExternalMixin
 
 log = getLogger(__name__)
 
 if TYPE_CHECKING:
     from gsy_e.models.market import MarketBase
+    from gsy_e.models.strategy import BaseStrategy
+    from gsy_e.models.strategy.new_base_strategy import NewStrategyBase
 
 
 class Area(AreaBase):
@@ -60,7 +62,7 @@ class Area(AreaBase):
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self, name: str = None, children: List["Area"] = None,
                  uuid: str = None,
-                 strategy: BaseStrategy = None,
+                 strategy: Optional[Union["BaseStrategy", "NewStrategyBase"]] = None,
                  config: SimulationConfig = None,
                  balancing_spot_trade_ratio=ConstSettings.BalancingSettings.SPOT_TRADE_RATIO,
                  event_list=None,

--- a/src/gsy_e/models/area/area.py
+++ b/src/gsy_e/models/area/area.py
@@ -49,7 +49,7 @@ log = getLogger(__name__)
 if TYPE_CHECKING:
     from gsy_e.models.market import MarketBase
     from gsy_e.models.strategy import BaseStrategy
-    from gsy_e.models.strategy.new_base_strategy import NewStrategyBase
+    from gsy_e.models.strategy.trading_strategy_base import TradingStrategyBase
 
 
 class Area(AreaBase):
@@ -62,7 +62,7 @@ class Area(AreaBase):
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self, name: str = None, children: List["Area"] = None,
                  uuid: str = None,
-                 strategy: Optional[Union["BaseStrategy", "NewStrategyBase"]] = None,
+                 strategy: Optional[Union["BaseStrategy", "TradingStrategyBase"]] = None,
                  config: SimulationConfig = None,
                  balancing_spot_trade_ratio=ConstSettings.BalancingSettings.SPOT_TRADE_RATIO,
                  event_list=None,

--- a/src/gsy_e/models/area/area_base.py
+++ b/src/gsy_e/models/area/area_base.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from gsy_e.models.area import Area
     from gsy_framework.data_classes import Trade
     from gsy_e.models.strategy import BaseStrategy
-    from gsy_e.models.strategy.new_base_strategy import NewStrategyBase
+    from gsy_e.models.strategy.trading_strategy_base import TradingStrategyBase
 
 
 def check_area_name_exists_in_parent_area(parent_area, name):
@@ -84,7 +84,7 @@ class AreaBase:
     def __init__(self, name: str = None,
                  children: List["Area"] = None,
                  uuid: str = None,
-                 strategy: Optional[Union["BaseStrategy", "NewStrategyBase"]] = None,
+                 strategy: Optional[Union["BaseStrategy", "TradingStrategyBase"]] = None,
                  config: SimulationConfig = None,
                  grid_fee_percentage: float = None,
                  grid_fee_constant: float = None):

--- a/src/gsy_e/models/area/area_base.py
+++ b/src/gsy_e/models/area/area_base.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from logging import getLogger
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Union, Optional
 from uuid import uuid4
 
 from gsy_framework.area_validator import validate_area
@@ -29,13 +29,15 @@ from slugify import slugify
 from gsy_e.gsy_e_core.exceptions import AreaException, GSyException
 from gsy_e.gsy_e_core.util import TaggedLogWrapper
 from gsy_e.models.config import SimulationConfig
-from gsy_e.models.strategy import BaseStrategy
+
 
 log = getLogger(__name__)
 
 if TYPE_CHECKING:
     from gsy_e.models.area import Area
     from gsy_framework.data_classes import Trade
+    from gsy_e.models.strategy import BaseStrategy
+    from gsy_e.models.strategy.new_base_strategy import NewStrategyBase
 
 
 def check_area_name_exists_in_parent_area(parent_area, name):
@@ -82,7 +84,7 @@ class AreaBase:
     def __init__(self, name: str = None,
                  children: List["Area"] = None,
                  uuid: str = None,
-                 strategy: BaseStrategy = None,
+                 strategy: Optional[Union["BaseStrategy", "NewStrategyBase"]] = None,
                  config: SimulationConfig = None,
                  grid_fee_percentage: float = None,
                  grid_fee_constant: float = None):

--- a/src/gsy_e/models/area/markets.py
+++ b/src/gsy_e/models/area/markets.py
@@ -19,10 +19,12 @@ from collections import OrderedDict
 from typing import Dict, TYPE_CHECKING, Optional, List
 
 from gsy_framework.constants_limits import ConstSettings, TIME_FORMAT
+from gsy_framework.enums import AvailableMarketTypes
 from gsy_framework.enums import SpotMarketTypeEnum
 from gsy_framework.utils import is_time_slot_in_simulation_duration
 from pendulum import DateTime
 
+from gsy_e.gsy_e_core.enums import FORWARD_MARKET_TYPES
 from gsy_e.models.area.market_rotators import (BaseRotator, DefaultMarketRotator,
                                                SettlementMarketRotator, FutureMarketRotator,
                                                ForwardMarketRotatorBase, DayForwardMarketRotator,
@@ -30,16 +32,14 @@ from gsy_e.models.area.market_rotators import (BaseRotator, DefaultMarketRotator
                                                YearForwardMarketRotator, IntradayMarketRotator)
 from gsy_e.models.market import GridFee, MarketBase
 from gsy_e.models.market.balancing import BalancingMarket
-from gsy_e.models.market.future import FutureMarkets
-from gsy_e.gsy_e_core.enums import FORWARD_MARKET_TYPES
-from gsy_framework.enums import AvailableMarketTypes
-from gsy_e.models.market.one_sided import OneSidedMarket
-from gsy_e.models.market.settlement import SettlementMarket
-from gsy_e.models.market.two_sided import TwoSidedMarket
 from gsy_e.models.market.forward import (
     ForwardMarketBase, DayForwardMarket, WeekForwardMarket, MonthForwardMarket, YearForwardMarket,
     IntradayMarket
 )
+from gsy_e.models.market.future import FutureMarkets
+from gsy_e.models.market.one_sided import OneSidedMarket
+from gsy_e.models.market.settlement import SettlementMarket
+from gsy_e.models.market.two_sided import TwoSidedMarket
 
 if TYPE_CHECKING:
     from gsy_e.models.area import Area
@@ -244,6 +244,7 @@ class AreaMarkets:
             name=area.name,
             in_sim_duration=is_time_slot_in_simulation_duration(time_slot, area.config)
         )
+        market.set_open_market_slot_parameters(time_slot, [time_slot])
 
         area.dispatcher.create_market_agents(market_type, market)
         return market

--- a/src/gsy_e/models/market/__init__.py
+++ b/src/gsy_e/models/market/__init__.py
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import uuid
-from abc import abstractmethod
 from collections import namedtuple
 from dataclasses import dataclass
 from functools import wraps
@@ -293,7 +292,6 @@ class MarketBase:  # pylint: disable=too-many-instance-attributes
         return sum(trade.trade_price for trade in self.trades if trade.seller == seller)
 
     @staticmethod
-    @abstractmethod
     def _calculate_closing_time(delivery_time: DateTime) -> DateTime:
         """
         Closing time of the market. Uses as basis the delivery time in order to calculate it.

--- a/src/gsy_e/models/market/__init__.py
+++ b/src/gsy_e/models/market/__init__.py
@@ -15,19 +15,20 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
 import uuid
+from abc import abstractmethod
 from collections import namedtuple
+from dataclasses import dataclass
 from functools import wraps
 from logging import getLogger
 from threading import RLock
-from typing import Dict, List, Union, Optional, Callable
+from typing import Dict, List, Union, Optional, Callable, TYPE_CHECKING
 
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
 from gsy_framework.data_classes import Offer, Trade, Bid
 from gsy_framework.enums import SpotMarketTypeEnum
 from numpy.random import random
-from pendulum import DateTime
+from pendulum import DateTime, duration
 
 from gsy_e.constants import FLOATING_POINT_TOLERANCE, DATE_TIME_FORMAT
 from gsy_e.gsy_e_core.device_registry import DeviceRegistry
@@ -37,6 +38,9 @@ from gsy_e.models.market.grid_fees.constant_grid_fees import ConstantGridFees
 from gsy_e.models.market.market_redis_connection import (
     MarketRedisEventSubscriber, MarketRedisEventPublisher,
     TwoSidedMarketRedisEventSubscriber)
+
+if TYPE_CHECKING:
+    from gsy_e.models.config import SimulationConfig
 
 log = getLogger(__name__)
 
@@ -59,6 +63,20 @@ def lock_market_action(function):
         with lock_object:
             return function(self, *args, **kwargs)
     return wrapper
+
+
+@dataclass(frozen=True)
+class MarketSlotParams:
+    """Parameters that describe a market slot."""
+    opening_time: DateTime
+    closing_time: DateTime
+    delivery_start_time: DateTime
+    delivery_end_time: DateTime
+
+    def __post_init__(self):
+        assert self.delivery_end_time > self.delivery_start_time
+        assert self.closing_time <= self.delivery_start_time
+        assert self.closing_time > self.opening_time
 
 
 class MarketBase:  # pylint: disable=too-many-instance-attributes
@@ -110,6 +128,8 @@ class MarketBase:  # pylint: disable=too-many-instance-attributes
                 if ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.ONE_SIDED.value
                 else TwoSidedMarketRedisEventSubscriber(self))
         setattr(self, RLOCK_MEMBER_NAME, RLock())
+
+        self._open_market_slot_parameters: Dict[DateTime, MarketSlotParams] = {}
 
     @property
     def time_slot_str(self):
@@ -271,3 +291,42 @@ class MarketBase:  # pylint: disable=too-many-instance-attributes
         """Return the aggregated money earned by the passed-in seller."""
 
         return sum(trade.trade_price for trade in self.trades if trade.seller == seller)
+
+    @staticmethod
+    @abstractmethod
+    def _calculate_closing_time(delivery_time: DateTime) -> DateTime:
+        """
+        Closing time of the market. Uses as basis the delivery time in order to calculate it.
+        """
+        return delivery_time + GlobalConfig.slot_length
+
+    @staticmethod
+    def _get_market_slot_duration(config: Optional["SimulationConfig"]) -> duration:
+        if config:
+            return config.slot_length
+        return GlobalConfig.slot_length
+
+    def get_market_parameters_for_market_slot(
+            self, market_slot: DateTime) -> MarketSlotParams:
+        """Retrieve the parameters for the selected market slot."""
+        return self._open_market_slot_parameters.get(market_slot)
+
+    @property
+    def open_market_slot_info(self) -> Dict[DateTime, MarketSlotParams]:
+        """Retrieve market slot parameters"""
+        return self._open_market_slot_parameters
+
+    def set_open_market_slot_parameters(
+            self, current_market_slot: DateTime, created_market_slots: Optional[List[DateTime]]):
+        """Update the parameters of the newly opened market slots."""
+        for market_slot in created_market_slots:
+            if market_slot in self._open_market_slot_parameters:
+                continue
+
+            self._open_market_slot_parameters[market_slot] = MarketSlotParams(
+                delivery_start_time=self._calculate_closing_time(market_slot),
+                delivery_end_time=self._calculate_closing_time(market_slot) +
+                self._get_market_slot_duration(None),
+                opening_time=current_market_slot,
+                closing_time=self._calculate_closing_time(market_slot)
+            )

--- a/src/gsy_e/models/market/forward.py
+++ b/src/gsy_e/models/market/forward.py
@@ -25,7 +25,7 @@ from pendulum import DateTime, duration
 
 from gsy_e.constants import FORWARD_MARKET_MAX_DURATION_YEARS
 from gsy_e.gsy_e_core.blockchain_interface import NonBlockchainInterface
-from gsy_e.models.market import GridFee
+from gsy_e.models.market import GridFee, MarketSlotParams
 from gsy_e.models.market.future import FutureMarkets
 
 if TYPE_CHECKING:
@@ -63,6 +63,21 @@ class ForwardMarketBase(FutureMarkets):
 
         self.set_open_market_slot_parameters(current_market_time_slot, created_future_slots)
         return created_future_slots
+
+    def set_open_market_slot_parameters(
+            self, current_market_slot: DateTime, created_market_slots: List[DateTime]):
+        """Update the parameters of the newly opened market slots."""
+        for market_slot in created_market_slots:
+            if market_slot in self._open_market_slot_parameters:
+                continue
+
+            self._open_market_slot_parameters[market_slot] = MarketSlotParams(
+                delivery_start_time=market_slot,
+                delivery_end_time=(
+                        market_slot + self._get_market_slot_duration(None)),
+                opening_time=current_market_slot,
+                closing_time=self._calculate_closing_time(market_slot)
+            )
 
 
 class IntradayMarket(ForwardMarketBase):

--- a/src/gsy_e/models/market/forward.py
+++ b/src/gsy_e/models/market/forward.py
@@ -16,9 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from dataclasses import dataclass
 from abc import abstractmethod
-from typing import Optional, TYPE_CHECKING, List, Dict
+from typing import Optional, TYPE_CHECKING, List
 
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.enums import AvailableMarketTypes
@@ -32,20 +31,6 @@ from gsy_e.models.market.future import FutureMarkets
 if TYPE_CHECKING:
     from gsy_e.models.config import SimulationConfig
     from gsy_e.models.area.event_dispatcher import AreaDispatcher
-
-
-@dataclass(frozen=True)
-class ForwardMarketSlot:
-    """Parameters that describe a forward market slot."""
-    opening_time: DateTime
-    closing_time: DateTime
-    delivery_start_time: DateTime
-    delivery_end_time: DateTime
-
-    def __post_init__(self):
-        assert self.delivery_end_time > self.delivery_start_time
-        assert self.closing_time <= self.delivery_start_time
-        assert self.closing_time > self.opening_time
 
 
 class ForwardMarketBase(FutureMarkets):
@@ -64,17 +49,11 @@ class ForwardMarketBase(FutureMarkets):
         super().__init__(bc=bc, notification_listener=notification_listener,
                          readonly=readonly, grid_fee_type=grid_fee_type,
                          grid_fees=grid_fees, name=name)
-        self._open_market_slot_parameters: Dict[DateTime, ForwardMarketSlot] = {}
 
     @property
     @abstractmethod
     def market_type(self):
         """Return the market type from the AvailableMarketTypes enum."""
-
-    @staticmethod
-    @abstractmethod
-    def _get_market_slot_duration(current_time: DateTime, _config) -> duration:
-        """Return duration of market slots inside the market block."""
 
     def create_future_market_slots(self, current_market_time_slot: DateTime,
                                    config: "SimulationConfig") -> List[DateTime]:
@@ -82,33 +61,8 @@ class ForwardMarketBase(FutureMarkets):
             return []
         created_future_slots = self._create_future_market_slots(config, current_market_time_slot)
 
-        self._set_open_market_slot_parameters(current_market_time_slot, created_future_slots)
+        self.set_open_market_slot_parameters(current_market_time_slot, created_future_slots)
         return created_future_slots
-
-    def get_market_parameters_for_market_slot(
-            self, market_slot: DateTime) -> ForwardMarketSlot:
-        """Retrieve the parameters for the selected market slot."""
-        return self._open_market_slot_parameters.get(market_slot)
-
-    @property
-    def open_market_slot_info(self) -> Dict[DateTime, ForwardMarketSlot]:
-        """Retrieve the parameters for the selected market slot."""
-        return self._open_market_slot_parameters
-
-    def _set_open_market_slot_parameters(
-            self, current_market_slot: DateTime, created_market_slots: List[DateTime]):
-        """Update the parameters of the newly opened market slots."""
-        for market_slot in created_market_slots:
-            if market_slot in self._open_market_slot_parameters:
-                continue
-
-            self._open_market_slot_parameters[market_slot] = ForwardMarketSlot(
-                delivery_start_time=market_slot,
-                delivery_end_time=(
-                        market_slot + self._get_market_slot_duration(market_slot, None)),
-                opening_time=current_market_slot,
-                closing_time=self._calculate_closing_time(market_slot)
-            )
 
 
 class IntradayMarket(ForwardMarketBase):
@@ -127,7 +81,7 @@ class IntradayMarket(ForwardMarketBase):
         return current_time.add(days=1)
 
     @staticmethod
-    def _get_market_slot_duration(_current_time: DateTime, _config) -> duration:
+    def _get_market_slot_duration(_config) -> duration:
         return duration(minutes=15)
 
     @staticmethod
@@ -160,7 +114,7 @@ class DayForwardMarket(ForwardMarketBase):
         return current_time.set(hour=0, minute=0).add(weeks=1, days=1, hours=-1)
 
     @staticmethod
-    def _get_market_slot_duration(_current_time: DateTime, _config) -> duration:
+    def _get_market_slot_duration(_config) -> duration:
         return duration(hours=1)
 
     @staticmethod
@@ -196,7 +150,7 @@ class WeekForwardMarket(ForwardMarketBase):
         return current_time.set(hour=0, minute=0).add(years=1)
 
     @staticmethod
-    def _get_market_slot_duration(_current_time: DateTime, _config) -> duration:
+    def _get_market_slot_duration(_config) -> duration:
         return duration(weeks=1)
 
     @staticmethod
@@ -232,7 +186,7 @@ class MonthForwardMarket(ForwardMarketBase):
         return current_time.set(day=1, hour=0, minute=0).add(years=2)
 
     @staticmethod
-    def _get_market_slot_duration(current_time: DateTime, _config) -> duration:
+    def _get_market_slot_duration(_config) -> duration:
         return duration(months=1)
 
     @staticmethod
@@ -268,7 +222,7 @@ class YearForwardMarket(ForwardMarketBase):
         return current_time.start_of("year").add(years=FORWARD_MARKET_MAX_DURATION_YEARS)
 
     @staticmethod
-    def _get_market_slot_duration(current_time: DateTime, _config) -> duration:
+    def _get_market_slot_duration(_config) -> duration:
         return duration(years=1)
 
     @staticmethod

--- a/src/gsy_e/models/market/future.py
+++ b/src/gsy_e/models/market/future.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, TYPE_CHECKING
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig, DATE_TIME_FORMAT
 from gsy_framework.data_classes import Bid, Offer, Trade
 from gsy_framework.utils import is_time_slot_in_simulation_duration
-from pendulum import DateTime
+from pendulum import DateTime, duration
 
 from gsy_e.gsy_e_core.blockchain_interface import NonBlockchainInterface
 from gsy_e.models.market import GridFee, lock_market_action, MarketSlotParams
@@ -296,6 +296,7 @@ class FutureMarkets(TwoSidedMarket):
                 delivery_start_time=market_slot,
                 delivery_end_time=(
                         market_slot + self._get_market_slot_duration(None)),
-                opening_time=current_market_slot,
+                opening_time=market_slot - duration(
+                    hours=ConstSettings.FutureMarketSettings.FUTURE_MARKET_DURATION_HOURS),
                 closing_time=self._calculate_closing_time(market_slot)
             )

--- a/src/gsy_e/models/market/future.py
+++ b/src/gsy_e/models/market/future.py
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # pylint: disable=too-many-arguments, too-many-locals, no-member
-from abc import abstractmethod
 from collections import UserDict
 from copy import deepcopy
 from logging import getLogger
@@ -25,11 +24,10 @@ from typing import Dict, List, Optional, TYPE_CHECKING
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig, DATE_TIME_FORMAT
 from gsy_framework.data_classes import Bid, Offer, Trade
 from gsy_framework.utils import is_time_slot_in_simulation_duration
-from pendulum import DateTime, duration
+from pendulum import DateTime
 
 from gsy_e.gsy_e_core.blockchain_interface import NonBlockchainInterface
-from gsy_e.models.market import GridFee
-from gsy_e.models.market import lock_market_action
+from gsy_e.models.market import GridFee, lock_market_action, MarketSlotParams
 from gsy_e.models.market.two_sided import TwoSidedMarket
 
 if TYPE_CHECKING:
@@ -193,11 +191,6 @@ class FutureMarkets(TwoSidedMarket):
             self.trades, last_slot_to_be_deleted)
 
     @staticmethod
-    def _get_market_slot_duration(_current_time: DateTime, config: "SimulationConfig") -> duration:
-        return config.slot_length
-
-    @staticmethod
-    @abstractmethod
     def _calculate_closing_time(delivery_time: DateTime) -> DateTime:
         """
         Closing time of the market. Uses as basis the delivery time in order to calculate it.
@@ -230,7 +223,7 @@ class FutureMarkets(TwoSidedMarket):
                 self.offers.slot_order_mapping[future_time_slot] = []
                 created_market_slots.append(future_time_slot)
             future_time_slot = (
-                future_time_slot + self._get_market_slot_duration(future_time_slot, config))
+                future_time_slot + self._get_market_slot_duration(config))
         return created_market_slots
 
     def create_future_market_slots(self, current_market_time_slot: DateTime,
@@ -238,7 +231,10 @@ class FutureMarkets(TwoSidedMarket):
         """Add sub dicts in order dictionaries for future market slots."""
         if not ConstSettings.FutureMarketSettings.FUTURE_MARKET_DURATION_HOURS:
             return []
-        return self._create_future_market_slots(config, current_market_time_slot)
+        created_future_slots = self._create_future_market_slots(config, current_market_time_slot)
+
+        self.set_open_market_slot_parameters(current_market_time_slot, created_future_slots)
+        return created_future_slots
 
     @lock_market_action
     def bid(self, price: float, energy: float, buyer: str, buyer_origin: str,
@@ -288,3 +284,18 @@ class FutureMarkets(TwoSidedMarket):
     def type_name(self):
         """Return the market type representation."""
         return "Future Market"
+
+    def set_open_market_slot_parameters(
+            self, current_market_slot: DateTime, created_market_slots: List[DateTime]):
+        """Update the parameters of the newly opened market slots."""
+        for market_slot in created_market_slots:
+            if market_slot in self._open_market_slot_parameters:
+                continue
+
+            self._open_market_slot_parameters[market_slot] = MarketSlotParams(
+                delivery_start_time=market_slot,
+                delivery_end_time=(
+                        market_slot + self._get_market_slot_duration(None)),
+                opening_time=current_market_slot,
+                closing_time=self._calculate_closing_time(market_slot)
+            )

--- a/src/gsy_e/models/strategy/forward/__init__.py
+++ b/src/gsy_e/models/strategy/forward/__init__.py
@@ -1,23 +1,19 @@
-from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict
 
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.enums import AvailableMarketTypes
-from pendulum import DateTime, duration
+from pendulum import duration
 
-from gsy_e.events import EventMixin
-from gsy_e.models.base import AreaBehaviorBase
 from gsy_e.models.strategy.forward.live_event_handler import ForwardLiveEvents
 from gsy_e.models.strategy.forward.order_updater import (
     ForwardOrderUpdater, ForwardOrderUpdaterParameters)
+from gsy_e.models.strategy.new_base_strategy import NewStrategyBase
 
 if TYPE_CHECKING:
-    from gsy_e.models.market.forward import ForwardMarketBase
     from gsy_e.models.state import StateInterface
-    from gsy_e.models.market import MarketBase
 
 
-class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
+class ForwardStrategyBase(NewStrategyBase):
     """Base class for the forward market strategies."""
     def __init__(self,
                  order_updater_parameters: Dict[
@@ -27,11 +23,10 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
             0.0 <=
             sum(params.capacity_percent for params in order_updater_parameters.values()) <=
             100.0)
-        super().__init__()
+
+        super().__init__(order_updater_parameters=order_updater_parameters)
+
         self._create_order_updater = ConstSettings.ForwardMarketSettings.FULLY_AUTO_TRADING
-        self._order_updater_params: Dict[AvailableMarketTypes,
-                                         ForwardOrderUpdaterParameters] = order_updater_parameters
-        self._order_updaters: Dict["MarketBase", Dict[DateTime, ForwardOrderUpdater]] = {}
         self._live_event_handler = ForwardLiveEvents(self)
 
     @staticmethod
@@ -46,18 +41,6 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
                 for market_type, updater_params in constructor_args["order_updater_params"].items()
             }
         return constructor_args
-
-    def _order_updater_for_market_slot_exists(self, market: "ForwardMarketBase", market_slot):
-        if market not in self._order_updaters:
-            return False
-        return market_slot in self._order_updaters[market]
-
-    def _update_open_orders(self):
-        for market, market_slot_updater_dict in self._order_updaters.items():
-            for market_slot, updater in market_slot_updater_dict.items():
-                if updater.is_time_for_update(self.area.now):
-                    self.remove_open_orders(market, market_slot)
-                    self.post_order(market, market_slot)
 
     def _post_orders_to_new_markets(self):
         forward_markets = self.area.forward_markets
@@ -77,51 +60,13 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
                     )
                     self.post_order(market, market_slot)
 
-    def _delete_past_order_updaters(self):
-        for market_object, market_slot_updater_dict in self._order_updaters.items():
-            slots_to_delete = []
-            for market_slot in market_slot_updater_dict.keys():
-                market_params = market_object.get_market_parameters_for_market_slot(market_slot)
-                if not market_params:
-                    slots_to_delete.append(market_slot)
-                    continue
-                if market_params.closing_time <= self.area.now:
-                    slots_to_delete.append(market_slot)
-            for slot in slots_to_delete:
-                market_slot_updater_dict.pop(slot)
-
-    @abstractmethod
-    def remove_open_orders(self, market: "ForwardMarketBase", market_slot: DateTime):
-        """Remove the open orders on the forward markets."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def post_order(self, market: "ForwardMarketBase", market_slot: DateTime,
-                   order_rate: float = None, capacity_percent: float = None):
-        """Post orders to the forward markets that just opened."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def remove_order(self, market: "ForwardMarketBase", market_slot: DateTime, order_uuid: str):
-        """Remove order from the selected forward market."""
-        raise NotImplementedError
-
-    def event_offer_traded(self, *, market_id, trade):
-        """Method triggered by the MarketEvent.OFFER_TRADED event."""
-
-    def event_bid_traded(self, *, market_id, bid_trade):
-        """Method triggered by the MarketEvent.BID_TRADED event."""
-
     @property
     def fully_automated_trading(self):
         """Is the strategy in fully automated trading mode."""
         return self._create_order_updater
 
-    def event_tick(self):
-        self._update_open_orders()
-
     def event_market_cycle(self):
-        self._delete_past_order_updaters()
+        super().event_market_cycle()
         if self.fully_automated_trading:
             self._post_orders_to_new_markets()
 

--- a/src/gsy_e/models/strategy/forward/__init__.py
+++ b/src/gsy_e/models/strategy/forward/__init__.py
@@ -14,6 +14,7 @@ from gsy_e.models.strategy.forward.order_updater import (
 if TYPE_CHECKING:
     from gsy_e.models.market.forward import ForwardMarketBase
     from gsy_e.models.state import StateInterface
+    from gsy_e.models.market import MarketBase
 
 
 class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
@@ -30,7 +31,7 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
         self._create_order_updater = ConstSettings.ForwardMarketSettings.FULLY_AUTO_TRADING
         self._order_updater_params: Dict[AvailableMarketTypes,
                                          ForwardOrderUpdaterParameters] = order_updater_parameters
-        self._order_updaters = {}
+        self._order_updaters: Dict["MarketBase", Dict[DateTime, ForwardOrderUpdater]] = {}
         self._live_event_handler = ForwardLiveEvents(self)
 
     @staticmethod
@@ -47,9 +48,9 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
         return constructor_args
 
     def _order_updater_for_market_slot_exists(self, market: "ForwardMarketBase", market_slot):
-        if market.id not in self._order_updaters:
+        if market not in self._order_updaters:
             return False
-        return market_slot in self._order_updaters[market.id]
+        return market_slot in self._order_updaters[market]
 
     def _update_open_orders(self):
         for market, market_slot_updater_dict in self._order_updaters.items():

--- a/src/gsy_e/models/strategy/forward/__init__.py
+++ b/src/gsy_e/models/strategy/forward/__init__.py
@@ -7,13 +7,13 @@ from pendulum import duration
 from gsy_e.models.strategy.forward.live_event_handler import ForwardLiveEvents
 from gsy_e.models.strategy.forward.order_updater import (
     ForwardOrderUpdater, ForwardOrderUpdaterParameters)
-from gsy_e.models.strategy.new_base_strategy import NewStrategyBase
+from gsy_e.models.strategy.trading_strategy_base import TradingStrategyBase
 
 if TYPE_CHECKING:
     from gsy_e.models.state import StateInterface
 
 
-class ForwardStrategyBase(NewStrategyBase):
+class ForwardStrategyBase(TradingStrategyBase):
     """Base class for the forward market strategies."""
     def __init__(self,
                  order_updater_parameters: Dict[

--- a/src/gsy_e/models/strategy/forward/__init__.py
+++ b/src/gsy_e/models/strategy/forward/__init__.py
@@ -8,7 +8,8 @@ from pendulum import DateTime, duration
 from gsy_e.events import EventMixin
 from gsy_e.models.base import AreaBehaviorBase
 from gsy_e.models.strategy.forward.live_event_handler import ForwardLiveEvents
-from gsy_e.models.strategy.forward.order_updater import OrderUpdater, OrderUpdaterParameters
+from gsy_e.models.strategy.forward.order_updater import (
+    ForwardOrderUpdater, ForwardOrderUpdaterParameters)
 
 if TYPE_CHECKING:
     from gsy_e.models.market.forward import ForwardMarketBase
@@ -18,7 +19,8 @@ if TYPE_CHECKING:
 class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
     """Base class for the forward market strategies."""
     def __init__(self,
-                 order_updater_parameters: Dict[AvailableMarketTypes, OrderUpdaterParameters]):
+                 order_updater_parameters: Dict[
+                     AvailableMarketTypes, ForwardOrderUpdaterParameters]):
         assert ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS is True
         assert (
             0.0 <=
@@ -27,7 +29,7 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
         super().__init__()
         self._create_order_updater = ConstSettings.ForwardMarketSettings.FULLY_AUTO_TRADING
         self._order_updater_params: Dict[AvailableMarketTypes,
-                                         OrderUpdaterParameters] = order_updater_parameters
+                                         ForwardOrderUpdaterParameters] = order_updater_parameters
         self._order_updaters = {}
         self._live_event_handler = ForwardLiveEvents(self)
 
@@ -36,7 +38,7 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
         """Deserialize the constructor arguments for the forward classes."""
         if "order_updater_params" in constructor_args:
             constructor_args["order_updater_params"] = {
-                AvailableMarketTypes(market_type): OrderUpdaterParameters(
+                AvailableMarketTypes(market_type): ForwardOrderUpdaterParameters(
                     duration(minutes=updater_params[0]), updater_params[1],
                     updater_params[2], updater_params[3]
                 )
@@ -68,7 +70,7 @@ class ForwardStrategyBase(EventMixin, AreaBehaviorBase, ABC):
                         market_parameters.closing_time <= self.area.now):
                     continue
                 if not self._order_updater_for_market_slot_exists(market, market_slot):
-                    self._order_updaters[market][market_slot] = OrderUpdater(
+                    self._order_updaters[market][market_slot] = ForwardOrderUpdater(
                         self._order_updater_params[market_type],
                         market_parameters
                     )

--- a/src/gsy_e/models/strategy/forward/live_event_handler.py
+++ b/src/gsy_e/models/strategy/forward/live_event_handler.py
@@ -114,7 +114,8 @@ class ForwardLiveEvents:
         energy_rate = args["energy_rate"]
         for slot in market.market_time_slots:
             if start_time <= slot <= end_time:
-                self._strategy.post_order(market, slot, capacity_percent, energy_rate)
+                self._strategy.post_order(market, slot, energy_rate,
+                                          capacity_percent=capacity_percent)
 
     @ForwardValidator.stop_trading
     def _remove_order_event(self, args: Dict):

--- a/src/gsy_e/models/strategy/forward/live_event_handler.py
+++ b/src/gsy_e/models/strategy/forward/live_event_handler.py
@@ -5,7 +5,7 @@ from gsy_framework.enums import AvailableMarketTypes
 from gsy_framework.live_events.b2b import LiveEventArgsValidator, B2BLiveEvents
 from gsy_framework.utils import str_to_pendulum_datetime
 
-from gsy_e.models.strategy.forward.order_updater import OrderUpdater
+from gsy_e.models.strategy.forward.order_updater import ForwardOrderUpdater
 
 
 class ForwardValidator:
@@ -95,7 +95,7 @@ class ForwardLiveEvents:
                 energy_rate),
                 order_updater_params.final_rate)
 
-            self._strategy._order_updaters[market][slot] = OrderUpdater(
+            self._strategy._order_updaters[market][slot] = ForwardOrderUpdater(
                 order_updater_params, market_parameters)
             self._strategy.post_order(market, slot)
 

--- a/src/gsy_e/models/strategy/forward/load.py
+++ b/src/gsy_e/models/strategy/forward/load.py
@@ -7,7 +7,7 @@ from gsy_e.constants import FLOATING_POINT_TOLERANCE
 from gsy_e.models.strategy.energy_parameters.energy_params_eb import (
     ConsumptionStandardProfileEnergyParameters)
 from gsy_e.models.strategy.forward import ForwardStrategyBase
-from gsy_e.models.strategy.forward.order_updater import OrderUpdaterParameters
+from gsy_e.models.strategy.forward.order_updater import ForwardOrderUpdaterParameters
 
 if TYPE_CHECKING:
     from gsy_e.models.market.forward import ForwardMarketBase
@@ -16,11 +16,16 @@ if TYPE_CHECKING:
 
 
 DEFAULT_LOAD_ORDER_UPDATER_PARAMS = {
-    AvailableMarketTypes.INTRADAY: OrderUpdaterParameters(duration(minutes=5), 10, 40, 10),
-    AvailableMarketTypes.DAY_FORWARD: OrderUpdaterParameters(duration(minutes=30), 20, 40, 10),
-    AvailableMarketTypes.WEEK_FORWARD: OrderUpdaterParameters(duration(days=1), 30, 50, 10),
-    AvailableMarketTypes.MONTH_FORWARD: OrderUpdaterParameters(duration(weeks=1), 40, 60, 20),
-    AvailableMarketTypes.YEAR_FORWARD: OrderUpdaterParameters(duration(months=1), 50, 70, 50)
+    AvailableMarketTypes.INTRADAY: ForwardOrderUpdaterParameters(
+        duration(minutes=5), 10, 40, 10),
+    AvailableMarketTypes.DAY_FORWARD: ForwardOrderUpdaterParameters(
+        duration(minutes=30), 20, 40, 10),
+    AvailableMarketTypes.WEEK_FORWARD: ForwardOrderUpdaterParameters(
+        duration(days=1), 30, 50, 10),
+    AvailableMarketTypes.MONTH_FORWARD: ForwardOrderUpdaterParameters(
+        duration(weeks=1), 40, 60, 20),
+    AvailableMarketTypes.YEAR_FORWARD: ForwardOrderUpdaterParameters(
+        duration(months=1), 50, 70, 50)
 }
 
 
@@ -31,7 +36,8 @@ class ForwardLoadStrategy(ForwardStrategyBase):
     """
     def __init__(
             self, capacity_kW: float,
-            order_updater_parameters: Dict[AvailableMarketTypes, OrderUpdaterParameters] = None):
+            order_updater_parameters: Dict[
+                AvailableMarketTypes, ForwardOrderUpdaterParameters] = None):
         if not order_updater_parameters:
             order_updater_parameters = DEFAULT_LOAD_ORDER_UPDATER_PARAMS
         super().__init__(order_updater_parameters)

--- a/src/gsy_e/models/strategy/forward/load.py
+++ b/src/gsy_e/models/strategy/forward/load.py
@@ -69,10 +69,11 @@ class ForwardLoadStrategy(ForwardStrategyBase):
 
     def post_order(
             self, market: "ForwardMarketBase", market_slot: DateTime, order_rate: float = None,
-            capacity_percent: float = None):
+            **kwargs):
         if not order_rate:
             order_rate = self._order_updaters[market][market_slot].get_energy_rate(
                 self.area.now)
+        capacity_percent = kwargs.get("capacity_percent")
         if not capacity_percent:
             capacity_percent = self._order_updaters[market][market_slot].capacity_percent / 100.0
         max_energy_kWh = self._energy_params.peak_energy_kWh * capacity_percent

--- a/src/gsy_e/models/strategy/forward/order_updater.py
+++ b/src/gsy_e/models/strategy/forward/order_updater.py
@@ -1,68 +1,31 @@
 from dataclasses import dataclass
 
-from pendulum import duration, DateTime, Duration
-
-from gsy_e.models.market.forward import ForwardMarketSlot
+from gsy_e.models.market import MarketSlotParams
+from gsy_e.models.strategy.order_updater import OrderUpdater, OrderUpdaterParameters
 
 
 @dataclass
-class OrderUpdaterParameters:
+class ForwardOrderUpdaterParameters(OrderUpdaterParameters):
     """
     Parameters of the order updater class. Includes start / end energy rate and time interval
     between each price update.
     """
-    update_interval: duration
-    initial_rate: float
-    final_rate: float
     capacity_percent: float
 
     def __post_init__(self):
         assert 0.0 <= self.capacity_percent <= 100.0
 
 
-class OrderUpdater:
+class ForwardOrderUpdater(OrderUpdater):
     """
     Calculate whether the price of the template strategy orders needs to be updated.
     Uses linear increase / decrease in price along the duration of a market slot.
     """
-    def __init__(self, parameters: OrderUpdaterParameters,
-                 market_params: ForwardMarketSlot):
-        self._parameters = parameters
-        self._market_params = market_params
-        self._update_times = self._calculate_update_timepoints(
-            self._market_params.opening_time, self._market_params.closing_time,
-            self._parameters.update_interval)
-
-    @staticmethod
-    def _calculate_update_timepoints(
-            start_time: DateTime, end_time: DateTime, interval: Duration):
-        current_time = start_time
-        timepoints = []
-        while current_time < end_time:
-            timepoints.append(current_time)
-            current_time += interval
-        return timepoints
-
-    def is_time_for_update(
-            self, current_time_slot: DateTime):
-        """Check if the orders need to be updated."""
-        return current_time_slot in self._update_times
+    def __init__(self, parameters: ForwardOrderUpdaterParameters,
+                 market_params: MarketSlotParams):
+        super().__init__(parameters=parameters, market_params=market_params)
 
     @property
     def capacity_percent(self):
         """Percentage of the total capacity that can be posted by this offer updater."""
         return self._parameters.capacity_percent
-
-    def get_energy_rate(self, current_time_slot: DateTime):
-        """Calculate energy rate for the current time slot."""
-        assert current_time_slot >= self._market_params.opening_time
-        time_elapsed_since_start = current_time_slot - self._market_params.opening_time
-        total_slot_length = (
-                self._market_params.closing_time - self._market_params.opening_time)
-        rate_range = abs(self._parameters.final_rate - self._parameters.initial_rate)
-        rate_diff_from_initial = (time_elapsed_since_start / total_slot_length) * rate_range
-        if self._parameters.initial_rate < self._parameters.final_rate:
-            return self._parameters.initial_rate + rate_diff_from_initial
-
-        assert (self._parameters.initial_rate - rate_diff_from_initial) >= 0.
-        return self._parameters.initial_rate - rate_diff_from_initial

--- a/src/gsy_e/models/strategy/forward/order_updater.py
+++ b/src/gsy_e/models/strategy/forward/order_updater.py
@@ -1,3 +1,21 @@
+"""
+Copyright 2018 Grid Singularity
+This file is part of Grid Singularity Exchange.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
 from dataclasses import dataclass
 
 from gsy_e.models.market import MarketSlotParams

--- a/src/gsy_e/models/strategy/forward/pv.py
+++ b/src/gsy_e/models/strategy/forward/pv.py
@@ -7,7 +7,7 @@ from gsy_e.constants import FLOATING_POINT_TOLERANCE
 from gsy_e.models.strategy.energy_parameters.energy_params_eb import (
     ProductionStandardProfileEnergyParameters)
 from gsy_e.models.strategy.forward import ForwardStrategyBase
-from gsy_e.models.strategy.forward.order_updater import OrderUpdaterParameters
+from gsy_e.models.strategy.forward.order_updater import ForwardOrderUpdaterParameters
 
 if TYPE_CHECKING:
     from gsy_e.models.market.forward import ForwardMarketBase
@@ -16,11 +16,16 @@ if TYPE_CHECKING:
 
 
 DEFAULT_PV_ORDER_UPDATER_PARAMS = {
-    AvailableMarketTypes.INTRADAY: OrderUpdaterParameters(duration(minutes=5), 10, 10, 10),
-    AvailableMarketTypes.DAY_FORWARD: OrderUpdaterParameters(duration(minutes=30), 10, 10, 10),
-    AvailableMarketTypes.WEEK_FORWARD: OrderUpdaterParameters(duration(days=1), 10, 10, 10),
-    AvailableMarketTypes.MONTH_FORWARD: OrderUpdaterParameters(duration(weeks=1), 10, 10, 20),
-    AvailableMarketTypes.YEAR_FORWARD: OrderUpdaterParameters(duration(months=1), 10, 10, 50)
+    AvailableMarketTypes.INTRADAY: ForwardOrderUpdaterParameters(
+        duration(minutes=5), 10, 10, 10),
+    AvailableMarketTypes.DAY_FORWARD: ForwardOrderUpdaterParameters(
+        duration(minutes=30), 10, 10, 10),
+    AvailableMarketTypes.WEEK_FORWARD: ForwardOrderUpdaterParameters(
+        duration(days=1), 10, 10, 10),
+    AvailableMarketTypes.MONTH_FORWARD: ForwardOrderUpdaterParameters(
+        duration(weeks=1), 10, 10, 20),
+    AvailableMarketTypes.YEAR_FORWARD: ForwardOrderUpdaterParameters(
+        duration(months=1), 10, 10, 50)
 }
 
 
@@ -31,7 +36,8 @@ class ForwardPVStrategy(ForwardStrategyBase):
     """
     def __init__(
             self, capacity_kW: float,
-            order_updater_parameters: Dict[AvailableMarketTypes, OrderUpdaterParameters] = None):
+            order_updater_parameters: Dict[
+                AvailableMarketTypes, ForwardOrderUpdaterParameters] = None):
         if not order_updater_parameters:
             order_updater_parameters = DEFAULT_PV_ORDER_UPDATER_PARAMS
 

--- a/src/gsy_e/models/strategy/forward/pv.py
+++ b/src/gsy_e/models/strategy/forward/pv.py
@@ -69,11 +69,11 @@ class ForwardPVStrategy(ForwardStrategyBase):
         market.delete_offer(offers[0])
 
     def post_order(self, market: "ForwardMarketBase", market_slot: DateTime,
-                   order_rate: float = None, capacity_percent: float = None):
+                   order_rate: float = None, **kwargs):
         if not order_rate:
             order_rate = self._order_updaters[market][market_slot].get_energy_rate(
                 self.area.now)
-
+        capacity_percent = kwargs.get("capacity_percent")
         if not capacity_percent:
             capacity_percent = self._order_updaters[market][market_slot].capacity_percent / 100.0
         max_energy_kWh = self._energy_params.peak_energy_kWh * capacity_percent

--- a/src/gsy_e/models/strategy/new_base_strategy.py
+++ b/src/gsy_e/models/strategy/new_base_strategy.py
@@ -1,0 +1,96 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Dict
+
+from gsy_framework.enums import AvailableMarketTypes
+from pendulum import DateTime, duration
+
+from gsy_e.events import EventMixin
+from gsy_e.models.base import AreaBehaviorBase
+from gsy_e.models.strategy.order_updater import (OrderUpdater, OrderUpdaterParameters)
+
+if TYPE_CHECKING:
+    from gsy_e.models.state import StateInterface
+    from gsy_e.models.market import MarketBase
+
+
+class NewStrategyBase(EventMixin, AreaBehaviorBase, ABC):
+    """Base class for the new market strategies."""
+    def __init__(self,
+                 order_updater_parameters: Dict[
+                     AvailableMarketTypes, OrderUpdaterParameters]):
+
+        super().__init__()
+        self._order_updater_params: Dict[AvailableMarketTypes,
+                                         OrderUpdaterParameters] = order_updater_parameters
+        self._order_updaters: Dict["MarketBase", Dict[DateTime, OrderUpdater]] = {}
+
+    @staticmethod
+    def deserialize_args(constructor_args: Dict) -> Dict:
+        """Deserialize the constructor arguments for the OrderUpdaterParameters."""
+        if "order_updater_params" in constructor_args:
+            constructor_args["order_updater_params"] = {
+                AvailableMarketTypes(market_type): OrderUpdaterParameters(
+                    duration(minutes=updater_params[0]), updater_params[1],
+                    updater_params[2]
+                )
+                for market_type, updater_params in constructor_args["order_updater_params"].items()
+            }
+        return constructor_args
+
+    def _order_updater_for_market_slot_exists(self, market: "MarketBase", market_slot):
+        if market not in self._order_updaters:
+            return False
+        return market_slot in self._order_updaters[market]
+
+    def _update_open_orders(self):
+        for market, market_slot_updater_dict in self._order_updaters.items():
+            for market_slot, updater in market_slot_updater_dict.items():
+                if updater.is_time_for_update(self.area.now):
+                    self.remove_open_orders(market, market_slot)
+                    self.post_order(market, market_slot)
+
+    def _delete_past_order_updaters(self):
+        for market_object, market_slot_updater_dict in self._order_updaters.items():
+            slots_to_delete = []
+            for market_slot in market_slot_updater_dict.keys():
+                market_params = market_object.get_market_parameters_for_market_slot(market_slot)
+                if not market_params:
+                    slots_to_delete.append(market_slot)
+                    continue
+                if market_params.closing_time <= self.area.now:
+                    slots_to_delete.append(market_slot)
+            for slot in slots_to_delete:
+                market_slot_updater_dict.pop(slot)
+
+    @abstractmethod
+    def remove_open_orders(self, market: "MarketBase", market_slot: DateTime):
+        """Remove the open orders on the markets."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def post_order(self, market: "MarketBase", market_slot: DateTime,
+                   order_rate: float = None, **kwargs):
+        """Post orders to the markets that just opened."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def remove_order(self, market: "MarketBase", market_slot: DateTime, order_uuid: str):
+        """Remove order from the selected market."""
+        raise NotImplementedError
+
+    def event_offer_traded(self, *, market_id, trade):
+        """Method triggered by the MarketEvent.OFFER_TRADED event."""
+
+    def event_bid_traded(self, *, market_id, bid_trade):
+        """Method triggered by the MarketEvent.BID_TRADED event."""
+
+    def event_tick(self):
+        self._update_open_orders()
+
+    def event_market_cycle(self):
+        self._delete_past_order_updaters()
+
+    @property
+    def state(self) -> "StateInterface":
+        """Get the state class of the strategy. Needs to be implemented by all strategies"""
+        raise NotImplementedError

--- a/src/gsy_e/models/strategy/order_updater.py
+++ b/src/gsy_e/models/strategy/order_updater.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+
+from pendulum import duration, DateTime, Duration
+from gsy_e.models.market import MarketSlotParams
+
+
+@dataclass
+class OrderUpdaterParameters:
+    """
+    Parameters of the order updater class. Includes start / end energy rate and time interval
+    between each price update.
+    """
+    update_interval: duration
+    initial_rate: float
+    final_rate: float
+
+
+class OrderUpdater:
+    """
+    Calculate whether the price of the template strategy orders needs to be updated.
+    Uses linear increase / decrease in price along the duration of a market slot.
+    """
+    def __init__(self, parameters: OrderUpdaterParameters,
+                 market_params: MarketSlotParams):
+        self._parameters = parameters
+        self._market_params = market_params
+        self._update_times = self._calculate_update_timepoints(
+            self._market_params.opening_time, self._market_params.closing_time,
+            self._parameters.update_interval)
+
+    @staticmethod
+    def _calculate_update_timepoints(
+            start_time: DateTime, end_time: DateTime, interval: Duration):
+        current_time = start_time
+        timepoints = []
+        while current_time < end_time:
+            timepoints.append(current_time)
+            current_time += interval
+        return timepoints
+
+    def is_time_for_update(
+            self, current_time_slot: DateTime):
+        """Check if the orders need to be updated."""
+        return current_time_slot in self._update_times
+
+    def get_energy_rate(self, current_time_slot: DateTime):
+        """Calculate energy rate for the current time slot."""
+        assert current_time_slot >= self._market_params.opening_time
+        time_elapsed_since_start = current_time_slot - self._market_params.opening_time
+        total_slot_length = (
+                self._market_params.closing_time - self._market_params.opening_time)
+        rate_range = abs(self._parameters.final_rate - self._parameters.initial_rate)
+        rate_diff_from_initial = (time_elapsed_since_start / total_slot_length) * rate_range
+        if self._parameters.initial_rate < self._parameters.final_rate:
+            return self._parameters.initial_rate + rate_diff_from_initial
+
+        assert (self._parameters.initial_rate - rate_diff_from_initial) >= 0.
+        return self._parameters.initial_rate - rate_diff_from_initial

--- a/src/gsy_e/models/strategy/trading_strategy_base.py
+++ b/src/gsy_e/models/strategy/trading_strategy_base.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from gsy_e.models.market import MarketBase
 
 
-class NewStrategyBase(EventMixin, AreaBehaviorBase, ABC):
+class TradingStrategyBase(EventMixin, AreaBehaviorBase, ABC):
     """Base class for the new market strategies."""
     def __init__(self,
                  order_updater_parameters: Dict[

--- a/src/gsy_e/setup/forward.py
+++ b/src/gsy_e/setup/forward.py
@@ -21,7 +21,7 @@ from pendulum import duration
 
 from gsy_e.models.area import Area
 from gsy_e.models.strategy.forward.load import ForwardLoadStrategy
-from gsy_e.models.strategy.forward.order_updater import OrderUpdaterParameters
+from gsy_e.models.strategy.forward.order_updater import ForwardOrderUpdaterParameters
 from gsy_e.models.strategy.forward.pv import ForwardPVStrategy
 
 ConstSettings.ForwardMarketSettings.ENABLE_FORWARD_MARKETS = True
@@ -29,20 +29,30 @@ ConstSettings.ForwardMarketSettings.FULLY_AUTO_TRADING = True
 ConstSettings.MASettings.MARKET_TYPE = SpotMarketTypeEnum.TWO_SIDED.value
 
 load_updaters = {
-    AvailableMarketTypes.INTRADAY: OrderUpdaterParameters(duration(minutes=5), 10, 40, 10),
-    AvailableMarketTypes.DAY_FORWARD: OrderUpdaterParameters(duration(minutes=30), 20, 40, 10),
-    AvailableMarketTypes.WEEK_FORWARD: OrderUpdaterParameters(duration(days=1), 30, 50, 10),
-    AvailableMarketTypes.MONTH_FORWARD: OrderUpdaterParameters(duration(weeks=1), 40, 60, 20),
-    AvailableMarketTypes.YEAR_FORWARD: OrderUpdaterParameters(duration(months=1), 50, 70, 50)
+    AvailableMarketTypes.INTRADAY: ForwardOrderUpdaterParameters(
+        duration(minutes=5), 10, 40, 10),
+    AvailableMarketTypes.DAY_FORWARD: ForwardOrderUpdaterParameters(
+        duration(minutes=30), 20, 40, 10),
+    AvailableMarketTypes.WEEK_FORWARD: ForwardOrderUpdaterParameters(
+        duration(days=1), 30, 50, 10),
+    AvailableMarketTypes.MONTH_FORWARD: ForwardOrderUpdaterParameters(
+        duration(weeks=1), 40, 60, 20),
+    AvailableMarketTypes.YEAR_FORWARD: ForwardOrderUpdaterParameters(
+        duration(months=1), 50, 70, 50)
 }
 
 
 pv_updaters = {
-    AvailableMarketTypes.INTRADAY: OrderUpdaterParameters(duration(minutes=5), 10, 10, 10),
-    AvailableMarketTypes.DAY_FORWARD: OrderUpdaterParameters(duration(minutes=30), 10, 10, 10),
-    AvailableMarketTypes.WEEK_FORWARD: OrderUpdaterParameters(duration(days=1), 10, 10, 10),
-    AvailableMarketTypes.MONTH_FORWARD: OrderUpdaterParameters(duration(weeks=1), 10, 10, 20),
-    AvailableMarketTypes.YEAR_FORWARD: OrderUpdaterParameters(duration(months=1), 10, 10, 50)
+    AvailableMarketTypes.INTRADAY: ForwardOrderUpdaterParameters(
+        duration(minutes=5), 10, 10, 10),
+    AvailableMarketTypes.DAY_FORWARD: ForwardOrderUpdaterParameters(
+        duration(minutes=30), 10, 10, 10),
+    AvailableMarketTypes.WEEK_FORWARD: ForwardOrderUpdaterParameters(
+        duration(days=1), 10, 10, 10),
+    AvailableMarketTypes.MONTH_FORWARD: ForwardOrderUpdaterParameters(
+        duration(weeks=1), 10, 10, 20),
+    AvailableMarketTypes.YEAR_FORWARD: ForwardOrderUpdaterParameters(
+        duration(months=1), 10, 10, 50)
 }
 
 

--- a/tests/strategies/forward/test_strategies.py
+++ b/tests/strategies/forward/test_strategies.py
@@ -10,7 +10,7 @@ from pendulum import duration, datetime
 
 from gsy_e.models.area import Area
 from gsy_e.models.strategy.forward.load import ForwardLoadStrategy
-from gsy_e.models.strategy.forward.order_updater import OrderUpdaterParameters
+from gsy_e.models.strategy.forward.order_updater import ForwardOrderUpdaterParameters
 from gsy_e.models.strategy.forward.pv import ForwardPVStrategy
 
 if TYPE_CHECKING:
@@ -19,20 +19,30 @@ if TYPE_CHECKING:
 CURRENT_MARKET_SLOT = datetime(2022, 6, 13, 0, 0)
 
 load_parameters = {
-    AvailableMarketTypes.INTRADAY: OrderUpdaterParameters(duration(minutes=5), 10, 40, 20),
-    AvailableMarketTypes.DAY_FORWARD: OrderUpdaterParameters(duration(minutes=30), 20, 40, 20),
-    AvailableMarketTypes.WEEK_FORWARD: OrderUpdaterParameters(duration(days=1), 30, 50, 20),
-    AvailableMarketTypes.MONTH_FORWARD: OrderUpdaterParameters(duration(weeks=1), 40, 60, 20),
-    AvailableMarketTypes.YEAR_FORWARD: OrderUpdaterParameters(duration(months=1), 50, 70, 20)
+    AvailableMarketTypes.INTRADAY: ForwardOrderUpdaterParameters(
+        duration(minutes=5), 10, 40, 20),
+    AvailableMarketTypes.DAY_FORWARD: ForwardOrderUpdaterParameters(
+        duration(minutes=30), 20, 40, 20),
+    AvailableMarketTypes.WEEK_FORWARD: ForwardOrderUpdaterParameters(
+        duration(days=1), 30, 50, 20),
+    AvailableMarketTypes.MONTH_FORWARD: ForwardOrderUpdaterParameters(
+        duration(weeks=1), 40, 60, 20),
+    AvailableMarketTypes.YEAR_FORWARD: ForwardOrderUpdaterParameters(
+        duration(months=1), 50, 70, 20)
 }
 
 
 pv_parameters = {
-    AvailableMarketTypes.INTRADAY: OrderUpdaterParameters(duration(minutes=5), 10, 8, 20),
-    AvailableMarketTypes.DAY_FORWARD: OrderUpdaterParameters(duration(minutes=30), 20, 18, 20),
-    AvailableMarketTypes.WEEK_FORWARD: OrderUpdaterParameters(duration(days=1), 30, 28, 20),
-    AvailableMarketTypes.MONTH_FORWARD: OrderUpdaterParameters(duration(weeks=1), 40, 38, 20),
-    AvailableMarketTypes.YEAR_FORWARD: OrderUpdaterParameters(duration(months=1), 50, 48, 20)
+    AvailableMarketTypes.INTRADAY: ForwardOrderUpdaterParameters(
+        duration(minutes=5), 10, 8, 20),
+    AvailableMarketTypes.DAY_FORWARD: ForwardOrderUpdaterParameters(
+        duration(minutes=30), 20, 18, 20),
+    AvailableMarketTypes.WEEK_FORWARD: ForwardOrderUpdaterParameters(
+        duration(days=1), 30, 28, 20),
+    AvailableMarketTypes.MONTH_FORWARD: ForwardOrderUpdaterParameters(
+        duration(weeks=1), 40, 38, 20),
+    AvailableMarketTypes.YEAR_FORWARD: ForwardOrderUpdaterParameters(
+        duration(months=1), 50, 48, 20)
 }
 
 


### PR DESCRIPTION
… used by normal strategies, too

## Reason for the proposed changes

For the heat pump strategy we like to re-use classes that were implemented for the forward markets.

## Proposed changes

- Moved OrdeUpdater out of the forward package [323a165](https://github.com/gridsingularity/gsy-e/pull/1565/commits/323a1652a2122a9133d3dc952b0bf1697e2fb6d8)
- Fixed a bug in the ForwardBaseStrategy [8e73427](https://github.com/gridsingularity/gsy-e/pull/1565/commits/8e73427f3d0e0b89fbcb8a21e9514f224a21eee5)
- Pulled re-usable functionality out of the ForwardStrategyBase class and moved it to the NewStrategyBase class [862bb65](https://github.com/gridsingularity/gsy-e/pull/1565/commits/862bb6509b36a43ac2fad6787bf8a85563e10f93)

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
