### PR TITLE
GSYE-444: Remove last_energy_trades_high_resolution

### DIFF
--- a/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
+++ b/src/gsy_e/gsy_e_core/sim_results/endpoint_buffer.py
@@ -69,7 +69,6 @@ class SimulationEndpointBuffer:
         }
 
         self.bids_offers_trades = {}
-        self.last_energy_trades_high_resolution = {}
         self.results_handler = self._create_endpoint_buffer(should_export_plots)
         self.simulation_state = {"general": {}, "areas": {}}
 


### PR DESCRIPTION
## Reason for the proposed changes
As requested by [GSYE-444](https://gridsingularity.atlassian.net/browse/GSYE-444), we want to want to remove all traces of high-resolution graphs for the offer/bid/trade and the energy trade profile

## Proposed changes

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
