### PR TITLE
Share tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,12 +45,6 @@ envdir = {toxworkdir}/setup
 skip_install = true
 commands = coverage erase
 
-[testenv:check_readme]
-envdir = {toxworkdir}/setup
-skip_install = true
-deps = readme_renderer
-commands = python setup.py check --restructuredtext --strict
-
 [testenv:integrationtests]
 envdir = {toxworkdir}/setup
 passenv = {[testenv]passenv} INTEGRATION_TESTS_REPO INTEGRATION_TESTS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 mintoxversion = 2.3
-envlist = check_readme,flake8,covclean,py38,coverage,integrationtests
+envlist = py38
 
 [flake8]
 max-line-length = 99
@@ -10,22 +10,30 @@ exclude = .tox,wiki,.cache,.d3a,.hypothesis,.pytest_cache,vagrant,requirements,v
 # environments unless overridden
 [testenv]
 basepython = python3.8
-passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH SOLC_BINARY GSY_FRAMEWORK_BRANCH
+passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH SOLC_BINARY GSY_FRAMEWORK_BRANCH OPENBLAS
 allowlist_externals =
     git
     /bin/rm
     /bin/ln
     bash
-commands_pre =
+    coverage
+
+[testenv:setup]
+passenv = {[testenv]passenv}
+commands =
     pip install --upgrade pip
     pip install -rrequirements/tests.txt
+    pip install -e .
+    pip uninstall -y gsy-framework
+    pip install git+https://github.com/gridsingularity/gsy-framework@{env:GSY_FRAMEWORK_BRANCH:master}
+
+[testenv:unittests]
+envdir = {toxworkdir}/setup
+commands =
+    pytest ./
 
 [testenv:coverage]
-skip_install = true
-deps = coverage
-commands_pre =
-    {[testenv]commands_pre}
-    pip install -e .
+envdir = {toxworkdir}/setup
 commands =
     coverage run -m pytest --random-order {posargs:tests}
     coverage combine
@@ -33,20 +41,21 @@ commands =
     coverage xml
 
 [testenv:covclean]
+envdir = {toxworkdir}/setup
 skip_install = true
-deps = {[testenv:coverage]deps}
 commands = coverage erase
 
 [testenv:check_readme]
+envdir = {toxworkdir}/setup
 skip_install = true
 deps = readme_renderer
 commands = python setup.py check --restructuredtext --strict
 
 [testenv:integrationtests]
+envdir = {toxworkdir}/setup
 passenv = {[testenv]passenv} INTEGRATION_TESTS_REPO INTEGRATION_TESTS_BRANCH
 commands_pre =
-    {[testenv]commands_pre}
-    pip install -e .
+    {[testenv:setup]commands}
     git clone \
         -b {env:INTEGRATION_TESTS_BRANCH:master} \
         {env:INTEGRATION_TESTS_REPO:git@github.com:gridsingularity/gsy-backend-integration-tests.git} \
@@ -57,15 +66,19 @@ commands =
 commands_post =
     rm ./integration_tests
 
+[testenv:pandapower-setup]
+envdir = {toxworkdir}/setup
+commands =
+    pip install -rrequirements/pandapower.txt
+
 [testenv:ci]
+envdir = {toxworkdir}/setup
 passenv = {[testenv:integrationtests]passenv}
-deps = {[testenv:coverage]deps}
 commands_pre =
     python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    pip install -rrequirements/pandapower.txt
+    {[testenv:setup]commands}
+    {[testenv:pandapower-setup]commands}
     {[testenv:integrationtests]commands_pre}
-    pip uninstall -y gsy-framework
-    pip install git+https://github.com/gridsingularity/gsy-framework@{env:GSY_FRAMEWORK_BRANCH:master}
 commands =
     flake8
     {[testenv:coverage]commands}
@@ -74,6 +87,7 @@ commands_post =
     {[testenv:integrationtests]commands_post}
 
 [testenv:test_dispatch_events_top_to_bottom]
+envdir = {toxworkdir}/setup
 passenv = {[testenv:integrationtests]passenv}
 setenv =
     DISPATCH_EVENTS_BOTTOM_TO_TOP = False


### PR DESCRIPTION
## Reason for the proposed changes

Main change involves sharing the same environment across all tox targets, thus allowing to separate the setup process to a separate target and creating dedicated targets for running the unit and integration tests that do not invoke the setup process (therefore do not try to reinstall the packages). 

The approach worked well in the terminal, however does not work well with the Pycharm tox runners. In order to configure it in Pycharm a configuration for unittests and setup needs to be created (in order to not have to invoke these via terminal but directly in your IDE):  
<img width="1045" alt="Screenshot 2022-12-21 at 09 49 49" src="https://user-images.githubusercontent.com/37290802/208861024-ecb4ba36-9e4e-43f5-874e-43d2645fabbc.png">

It generally works, what does not work though is the ability to run individual tests through tox, because the Pycharm tox runner does not support this. 

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
