### PR TITLE
GSYE-496: Added missing fields (e.g. base_energy_bill_revenue) from t…

### DIFF
--- a/src/gsy_e/models/area/scm_manager.py
+++ b/src/gsy_e/models/area/scm_manager.py
@@ -259,12 +259,16 @@ class AreaEnergyBills:  # pylint: disable=too-many-instance-attributes
         # will be negative, and the producer will not have "savings". For a more realistic case
         # the revenue should be omitted from the calculation of the savings, however this needs
         # to be discussed.
-        return KPICalculationHelper().saving_absolute(self.base_energy_bill, self.gsy_energy_bill)
+        savings_absolute = KPICalculationHelper().saving_absolute(
+            self.base_energy_bill_excl_revenue, self.gsy_energy_bill_excl_revenue)
+        assert savings_absolute > -FLOATING_POINT_TOLERANCE
+        return savings_absolute
 
     @property
     def savings_percent(self):
         """Percentage of the price savings of the home, compared to the base energy bill."""
-        return KPICalculationHelper().saving_percentage(self.savings, self.base_energy_bill)
+        return KPICalculationHelper().saving_percentage(
+            self.savings, self.base_energy_bill_excl_revenue)
 
     @property
     def energy_benchmark(self):
@@ -521,13 +525,20 @@ class SCMManager:
         community_bills = AreaEnergyBills()
         for data in self._bills.values():
             community_bills.base_energy_bill += data.base_energy_bill
+            community_bills.base_energy_bill_revenue += data.base_energy_bill_revenue
             community_bills.gsy_energy_bill += data.gsy_energy_bill
+            community_bills.base_energy_bill_excl_revenue += data.base_energy_bill_excl_revenue
+
             community_bills.bought_from_community += data.bought_from_community
             community_bills.spent_to_community += data.spent_to_community
+            community_bills.sold_to_community += data.sold_to_community
+            community_bills.earned_from_community += data.earned_from_community
+
             community_bills.bought_from_grid += data.bought_from_grid
             community_bills.spent_to_grid += data.spent_to_grid
             community_bills.sold_to_grid += data.sold_to_grid
             community_bills.earned_from_grid += data.earned_from_grid
+
             community_bills.tax_surcharges += data.tax_surcharges
             community_bills.grid_fees += data.grid_fees
             community_bills.marketplace_fee += data.marketplace_fee

--- a/tests/area/test_coefficient_area.py
+++ b/tests/area/test_coefficient_area.py
@@ -162,7 +162,9 @@ class TestCoefficientArea:
         assert isclose(scm._bills[house2.uuid].base_energy_bill_excl_revenue, 0.0)
         assert isclose(scm._bills[house2.uuid].base_energy_bill_revenue, 0.005)
         assert isclose(scm._bills[house2.uuid].gsy_energy_bill, -0.0164)
-        assert isclose(scm._bills[house2.uuid].savings, 0.0114)
+
+        assert isclose(scm._bills[house2.uuid].savings,
+                       0.0, abs_tol=constants.FLOATING_POINT_TOLERANCE)
         assert isclose(scm._bills[house2.uuid].savings_percent, 0.0)
         assert len(scm._home_data[house1.uuid].trades) == 2
         trades = scm._home_data[house1.uuid].trades
@@ -189,7 +191,7 @@ class TestCoefficientArea:
     def test_calculate_energy_benchmark():
         bills = AreaEnergyBills()
         bills.set_min_max_community_savings(10, 90)
-        bills.base_energy_bill = 1.0
+        bills.base_energy_bill_excl_revenue = 1.0
         bills.gsy_energy_bill = 0.4
         assert isclose(bills.savings_percent, 60.0)
         assert isclose(bills.energy_benchmark, (60 - 10) / (90 - 10))


### PR DESCRIPTION
…he community results sent to the results service. Fixed the savings and savings_percent calculation to be based on the energy bills that exclude the revenue, and added assertion that checks that savings is always non-negative.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
