### PR TITLE
Disable the triggering of the garbage collector and the debug calcula…

### DIFF
--- a/src/gsy_e/gsy_e_core/simulation/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation/simulation.py
@@ -485,7 +485,7 @@ class CoefficientSimulation(Simulation):
 
             self._external_events.update(self.area)
 
-            self._compute_memory_info()
+            # self._compute_memory_info()
 
             self._time.handle_slowdown_and_realtime_scm(slot_no, slot_count, self.config)
 


### PR DESCRIPTION
…tion of the memory information on SCM, since it contributed a significant amount of the SCM runtime.

## Reason for the proposed changes

The garbage collector invocation and the process memory calculation had detrimental effect on the performance of the SCM simulation. Around 40% of the simulation runtime was spent on the commented-out method which significantly slowed down the SCM simulation especially for longer simulation durations. 

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
