### PR TITLE
Fix handling of case when aggregator_device_mapping is an empty dict

### DIFF
--- a/src/gsy_e/models/config.py
+++ b/src/gsy_e/models/config.py
@@ -31,6 +31,7 @@ from gsy_e.gsy_e_core.util import change_global_config, format_interval
 
 class SimulationConfig:
     """Class defining parameters that describe the behavior of a simulation."""
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
     def __init__(self, sim_duration: duration, slot_length: duration, tick_length: duration,
                  cloud_coverage: int,
                  market_maker_rate=ConstSettings.GeneralSettings.DEFAULT_MARKET_MAKER_RATE,
@@ -86,7 +87,7 @@ class SimulationConfig:
         self.external_connection_enabled = external_connection_enabled
         self.external_redis_communicator = external_redis_communicator_factory(
             external_connection_enabled)
-        if aggregator_device_mapping is not None:
+        if aggregator_device_mapping:
             self.external_redis_communicator.aggregator.set_aggregator_device_mapping(
                 aggregator_device_mapping
             )

--- a/tests/test_rq_job_utils.py
+++ b/tests/test_rq_job_utils.py
@@ -46,7 +46,7 @@ class TestRQJobUtils:
                "tick_length": duration(minutes=6)
             },
             "events": None,
-            "aggregator_device_mapping": "null",
+            "aggregator_device_mapping": {},
             "saved_state": None,
             "job_id": "TEST_SIM_RUNS",
             "connect_to_profiles_db": False


### PR DESCRIPTION
## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
