### PR TITLE
GSYE-434: Fix ExternalSCMLoadStrategy

### DIFF
--- a/src/gsy_e/gsy_e_core/area_serializer.py
+++ b/src/gsy_e/gsy_e_core/area_serializer.py
@@ -38,7 +38,7 @@ from gsy_e.models.strategy.finite_power_plant import FinitePowerPlant # NOQA
 
 from gsy_e.models.leaves import (
     Leaf, scm_leaf_mapping, CoefficientLeaf, forward_leaf_mapping,
-    external_scm_leaf_mapping) # NOQA
+    forecast_scm_leaf_mapping) # NOQA
 from gsy_e.models.leaves import *  # NOQA  # pylint: disable=wildcard-import
 
 logger = getLogger(__name__)
@@ -129,7 +129,7 @@ def _leaf_from_dict(description, config):
         strategy_type = description.pop("type")
         if (config.external_connection_enabled and
                 description.get("forecast_stream_enabled", False) is True):
-            leaf_type = external_scm_leaf_mapping.get(strategy_type)
+            leaf_type = forecast_scm_leaf_mapping.get(strategy_type)
         else:
             leaf_type = scm_leaf_mapping.get(strategy_type)
         if not leaf_type:

--- a/src/gsy_e/models/leaves.py
+++ b/src/gsy_e/models/leaves.py
@@ -40,8 +40,8 @@ from gsy_e.models.strategy.predefined_load import DefinedLoadStrategy
 from gsy_e.models.strategy.predefined_pv import PVPredefinedStrategy, PVUserProfileStrategy
 from gsy_e.models.strategy.predefined_wind import WindUserProfileStrategy
 from gsy_e.models.strategy.pv import PVStrategy
-from gsy_e.models.strategy.scm.external.load import ExternalSCMLoadStrategy
-from gsy_e.models.strategy.scm.external.pv import ExternalSCMPVStrategy
+from gsy_e.models.strategy.scm.external.load import ForecastSCMLoadStrategy
+from gsy_e.models.strategy.scm.external.pv import ForecastSCMPVStrategy
 from gsy_e.models.strategy.scm.load import SCMLoadHoursStrategy, SCMLoadProfileStrategy
 from gsy_e.models.strategy.scm.pv import SCMPVPredefinedStrategy, SCMPVStrategy, SCMPVUserProfile
 from gsy_e.models.strategy.scm.storage import SCMStorageStrategy
@@ -228,12 +228,12 @@ class SCMStorage(CoefficientLeaf):
     strategy_type = SCMStorageStrategy
 
 
-class ExternalSCMLoad(CoefficientLeaf):
-    strategy_type = ExternalSCMLoadStrategy
+class ForecastSCMLoad(CoefficientLeaf):
+    strategy_type = ForecastSCMLoadStrategy
 
 
-class ExternalSCMPV(CoefficientLeaf):
-    strategy_type = ExternalSCMPVStrategy
+class ForecastSCMPV(CoefficientLeaf):
+    strategy_type = ForecastSCMPVStrategy
 
 
 scm_leaf_mapping = {
@@ -245,12 +245,12 @@ scm_leaf_mapping = {
     "PVProfile": SCMPVProfile
 }
 
-external_scm_leaf_mapping = {
-    "LoadHours": ExternalSCMLoad,
-    "LoadProfile": ExternalSCMLoad,
-    "PV": ExternalSCMPV,
-    "PredefinedPV": ExternalSCMPV,
-    "PVProfile": ExternalSCMPV
+forecast_scm_leaf_mapping = {
+    "LoadHours": ForecastSCMLoad,
+    "LoadProfile": ForecastSCMLoad,
+    "PV": ForecastSCMPV,
+    "PredefinedPV": ForecastSCMPV,
+    "PVProfile": ForecastSCMPV
 }
 
 forward_leaf_mapping = {

--- a/src/gsy_e/models/strategy/profile.py
+++ b/src/gsy_e/models/strategy/profile.py
@@ -1,3 +1,4 @@
+from gsy_framework.exceptions import GSyException
 from gsy_framework.read_user_profile import InputProfileTypes, convert_identity_profile_to_float
 
 from gsy_e.gsy_e_core.global_objects_singleton import global_objects
@@ -9,6 +10,10 @@ class EnergyProfile:
     def __init__(
             self, input_profile=None, input_profile_uuid=None,
             input_energy_rate=None, profile_type: InputProfileTypes = None):
+
+        if input_profile is None and input_profile_uuid is None and input_energy_rate is None:
+            raise GSyException(
+                "EnergyProfile: All input parameters are None, one of them has to be set.")
 
         self.input_profile = input_profile
         self.input_profile_uuid = input_profile_uuid

--- a/src/gsy_e/models/strategy/profile.py
+++ b/src/gsy_e/models/strategy/profile.py
@@ -1,4 +1,3 @@
-from gsy_framework.exceptions import GSyException
 from gsy_framework.read_user_profile import InputProfileTypes, convert_identity_profile_to_float
 
 from gsy_e.gsy_e_core.global_objects_singleton import global_objects
@@ -10,10 +9,6 @@ class EnergyProfile:
     def __init__(
             self, input_profile=None, input_profile_uuid=None,
             input_energy_rate=None, profile_type: InputProfileTypes = None):
-
-        if input_profile is None and input_profile_uuid is None and input_energy_rate is None:
-            raise GSyException(
-                "EnergyProfile: All input parameters are None, one of them has to be set.")
 
         self.input_profile = input_profile
         self.input_profile_uuid = input_profile_uuid

--- a/src/gsy_e/models/strategy/scm/external/load.py
+++ b/src/gsy_e/models/strategy/scm/external/load.py
@@ -19,7 +19,7 @@ from gsy_e.models.strategy.scm.external.forecast_mixin import SCMForecastExterna
 from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy
 
 
-class ExternalSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
+class ForecastSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
     """External SCM Load strategy"""
 
     def update_energy_forecast(self) -> None:

--- a/src/gsy_e/models/strategy/scm/external/load.py
+++ b/src/gsy_e/models/strategy/scm/external/load.py
@@ -22,6 +22,12 @@ from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy
 class ForecastSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
     """External SCM Load strategy"""
 
+    def activate(self, area) -> None:
+        """Overwrite in order to not trigger the profile rotation."""
+
+    def _update_energy_requirement(self, _area):
+        """Overwrite method that sets the energy requirement in the state."""
+
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""
         for slot_time, energy_kWh in self.energy_forecast_buffer.items():

--- a/src/gsy_e/models/strategy/scm/external/load.py
+++ b/src/gsy_e/models/strategy/scm/external/load.py
@@ -16,11 +16,14 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from gsy_e.models.strategy.scm.external.forecast_mixin import SCMForecastExternalMixin
-from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy
+from gsy_e.models.strategy.scm.load import SCMLoadHoursStrategy
 
 
-class ExternalSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
+class ExternalSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadHoursStrategy):
     """External SCM Load strategy"""
+
+    def __init__(self):
+        super().__init__(avg_power_W=0)
 
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""

--- a/src/gsy_e/models/strategy/scm/external/load.py
+++ b/src/gsy_e/models/strategy/scm/external/load.py
@@ -16,14 +16,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from gsy_e.models.strategy.scm.external.forecast_mixin import SCMForecastExternalMixin
-from gsy_e.models.strategy.scm.load import SCMLoadHoursStrategy
+from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy
 
 
-class ExternalSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadHoursStrategy):
+class ExternalSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
     """External SCM Load strategy"""
-
-    def __init__(self):
-        super().__init__(avg_power_W=0)
 
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""

--- a/src/gsy_e/models/strategy/scm/external/pv.py
+++ b/src/gsy_e/models/strategy/scm/external/pv.py
@@ -19,7 +19,7 @@ from gsy_e.models.strategy.scm.external.forecast_mixin import SCMForecastExterna
 from gsy_e.models.strategy.scm.pv import SCMPVUserProfile
 
 
-class ExternalSCMPVStrategy(SCMForecastExternalMixin, SCMPVUserProfile):
+class ForecastSCMPVStrategy(SCMForecastExternalMixin, SCMPVUserProfile):
     """External SCM PV strategy"""
 
     def update_energy_forecast(self) -> None:

--- a/src/gsy_e/models/strategy/scm/external/pv.py
+++ b/src/gsy_e/models/strategy/scm/external/pv.py
@@ -16,15 +16,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from gsy_e.models.strategy.scm.external.forecast_mixin import SCMForecastExternalMixin
-from gsy_e.models.strategy.scm.pv import (
-    SCMPVStrategy)
+from gsy_e.models.strategy.scm.pv import SCMPVUserProfile
 
 
-class ExternalSCMPVStrategy(SCMForecastExternalMixin, SCMPVStrategy):
+class ExternalSCMPVStrategy(SCMForecastExternalMixin, SCMPVUserProfile):
     """External SCM PV strategy"""
-
-    def __init__(self, capacity_kW: float = None):
-        super().__init__(capacity_kW=capacity_kW)
 
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""

--- a/src/gsy_e/models/strategy/scm/external/pv.py
+++ b/src/gsy_e/models/strategy/scm/external/pv.py
@@ -22,6 +22,9 @@ from gsy_e.models.strategy.scm.pv import SCMPVUserProfile
 class ForecastSCMPVStrategy(SCMForecastExternalMixin, SCMPVUserProfile):
     """External SCM PV strategy"""
 
+    def _update_forecast_in_state(self, _area):
+        """Overwrite method that sets the forecasted energy in the state."""
+
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""
         for slot_time, energy_kWh in self.energy_forecast_buffer.items():

--- a/src/gsy_e/models/strategy/scm/load.py
+++ b/src/gsy_e/models/strategy/scm/load.py
@@ -81,11 +81,13 @@ class SCMLoadProfileStrategy(SCMStrategy):
         """Activate the strategy."""
         self._energy_params.event_activate_energy(area)
 
+    def _update_energy_requirement(self, area: "AreaBase") -> None:
+        self._energy_params.energy_profile.read_or_rotate_profiles()
+        self._energy_params.update_energy_requirement(area.current_market_time_slot, area.name)
+
     def market_cycle(self, area: "AreaBase") -> None:
         """Update the load forecast and measurements for the next/previous market slot."""
-        self._energy_params.energy_profile.read_or_rotate_profiles()
-        slot_time = area.current_market_time_slot
-        self._energy_params.update_energy_requirement(slot_time, area.name)
+        self._update_energy_requirement(area)
 
     def get_available_energy_kWh(self, time_slot: DateTime) -> float:
         """Get the available energy for consumption for the specified time slot."""

--- a/src/gsy_e/setup/scm/external.py
+++ b/src/gsy_e/setup/scm/external.py
@@ -46,9 +46,9 @@ def get_setup(config):
                 "House 2",
                 [
                     CoefficientArea("forecast-measurement-load",
-                                    strategy=ForecastSCMLoadStrategy(daily_load_profile={0: 100})),
+                                    strategy=ForecastSCMLoadStrategy()),
                     CoefficientArea("forecast-measurement-pv",
-                                    strategy=ForecastSCMPVStrategy(power_profile={0: 100})),
+                                    strategy=ForecastSCMPVStrategy()),
                     CoefficientArea("H2 Smart Meter",
                                     strategy=SCMSmartMeterStrategy(smart_meter_profile={0: 100})),
                 ],

--- a/src/gsy_e/setup/scm/external.py
+++ b/src/gsy_e/setup/scm/external.py
@@ -18,8 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from gsy_e.constants import DEFAULT_SCM_COMMUNITY_NAME
 from gsy_e.models.area import CoefficientArea
 from gsy_e.models.strategy.scm.load import SCMLoadHoursStrategy
-from gsy_e.models.strategy.scm.external.pv import ExternalSCMPVStrategy
-from gsy_e.models.strategy.scm.external.load import ExternalSCMLoadStrategy
+from gsy_e.models.strategy.scm.external.pv import ForecastSCMPVStrategy
+from gsy_e.models.strategy.scm.external.load import ForecastSCMLoadStrategy
 from gsy_e.models.strategy.scm.pv import SCMPVStrategy
 from gsy_e.models.strategy.scm.smart_meter import SCMSmartMeterStrategy
 from gsy_e.models.strategy.scm.storage import SCMStorageStrategy
@@ -46,9 +46,9 @@ def get_setup(config):
                 "House 2",
                 [
                     CoefficientArea("forecast-measurement-load",
-                                    strategy=ExternalSCMLoadStrategy(daily_load_profile={0: 100})),
+                                    strategy=ForecastSCMLoadStrategy(daily_load_profile={0: 100})),
                     CoefficientArea("forecast-measurement-pv",
-                                    strategy=ExternalSCMPVStrategy(power_profile={0: 100})),
+                                    strategy=ForecastSCMPVStrategy(power_profile={0: 100})),
                     CoefficientArea("H2 Smart Meter",
                                     strategy=SCMSmartMeterStrategy(smart_meter_profile={0: 100})),
                 ],

--- a/src/gsy_e/setup/scm/external.py
+++ b/src/gsy_e/setup/scm/external.py
@@ -15,9 +15,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
-from gsy_framework.constants_limits import ConstSettings, SpotMarketTypeEnum
-
 from gsy_e.constants import DEFAULT_SCM_COMMUNITY_NAME
 from gsy_e.models.area import CoefficientArea
 from gsy_e.models.strategy.scm.load import SCMLoadHoursStrategy
@@ -26,8 +23,6 @@ from gsy_e.models.strategy.scm.external.load import ExternalSCMLoadStrategy
 from gsy_e.models.strategy.scm.pv import SCMPVStrategy
 from gsy_e.models.strategy.scm.smart_meter import SCMSmartMeterStrategy
 from gsy_e.models.strategy.scm.storage import SCMStorageStrategy
-
-ConstSettings.MASettings.MARKET_TYPE = SpotMarketTypeEnum.COEFFICIENTS.value
 
 
 def get_setup(config):

--- a/src/gsy_e/setup/scm/external.py
+++ b/src/gsy_e/setup/scm/external.py
@@ -46,8 +46,9 @@ def get_setup(config):
                 "House 2",
                 [
                     CoefficientArea("forecast-measurement-load",
-                                    strategy=ExternalSCMLoadStrategy()),
-                    CoefficientArea("forecast-measurement-pv", strategy=ExternalSCMPVStrategy()),
+                                    strategy=ExternalSCMLoadStrategy(daily_load_profile={0: 100})),
+                    CoefficientArea("forecast-measurement-pv",
+                                    strategy=ExternalSCMPVStrategy(power_profile={0: 100})),
                     CoefficientArea("H2 Smart Meter",
                                     strategy=SCMSmartMeterStrategy(smart_meter_profile={0: 100})),
                 ],


### PR DESCRIPTION
We need the SCMLoadHoursStrategy in  the ExternalSCMLoadStrategy in order to initiate a profile with 0 values for the forecast SCM strategies.
I also propose to rename the ExternalSCMLoadStrategy into ForecastSCMLoadStrategy. What do you think @spyrostz ?

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=feature/GSYE-434
**GSY_FRAMEWORK_BRANCH**=master
