### PR TITLE
event_activate method is not used by the SCM strategies, but only fro…

### DIFF
--- a/src/gsy_e/models/strategy/scm/external/forecast_mixin.py
+++ b/src/gsy_e/models/strategy/scm/external/forecast_mixin.py
@@ -16,14 +16,30 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
+from gsy_framework.redis_channels import ExternalStrategyChannels
+
+import gsy_e
 from gsy_e.constants import DATE_TIME_FORMAT
 from gsy_e.models.strategy.external_strategies.forecast_mixin import ForecastExternalMixin
+
+if TYPE_CHECKING:
+    from gsy_e.models.area import CoefficientArea
 
 
 class SCMForecastExternalMixin(ForecastExternalMixin):
     """External mixin for forecast strategies in SCM simulations."""
+
+    def activate(self, _area: "CoefficientArea") -> None:
+        """Overwrite in order to not trigger the profile rotation."""
+        self.channel_names = ExternalStrategyChannels(
+            gsy_e.constants.EXTERNAL_CONNECTION_WEB,
+            gsy_e.constants.CONFIGURATION_ID,
+            asset_uuid=self.device.uuid,
+            asset_name=self.device.name
+        )
+        self.sub_to_redis_channels()
 
     def sub_to_redis_channels(self):
         """Subscribe to redis channels for (un-)registering."""

--- a/src/gsy_e/models/strategy/scm/external/load.py
+++ b/src/gsy_e/models/strategy/scm/external/load.py
@@ -22,10 +22,6 @@ from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy
 class ForecastSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
     """External SCM Load strategy"""
 
-    def activate(self, area) -> None:
-        """Overwrite in order to not trigger the profile rotation."""
-        self.sub_to_redis_channels()
-
     def _update_energy_requirement(self, _area):
         """Overwrite method that sets the energy requirement in the state."""
 

--- a/src/gsy_e/models/strategy/scm/external/pv.py
+++ b/src/gsy_e/models/strategy/scm/external/pv.py
@@ -29,10 +29,6 @@ class ForecastSCMPVStrategy(SCMForecastExternalMixin, SCMPVUserProfile):
         """TODO: Remove quickfix of GSYE-581 and remove the unused capacity_kW"""
         super().__init__(power_profile=power_profile, power_profile_uuid=power_profile_uuid)
 
-    def activate(self, area) -> None:
-        """Overwrite in order to not trigger the profile rotation."""
-        self.sub_to_redis_channels()
-
     def _update_forecast_in_state(self, _area):
         """Overwrite method that sets the forecasted energy in the state."""
 


### PR DESCRIPTION
…m the normal ones. In order to support the channel setup in SCM too, the channel_names member variable needs to be populated on the activate() method of the SCMForecastExternalMixin. Added unit tests to validate the expected behavior.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
