### PR TITLE
Removed dev-addr from mkdocs serve in order to not use the dev addr a…

### DIFF
--- a/wiki/mkdocs-material/Dockerfile
+++ b/wiki/mkdocs-material/Dockerfile
@@ -47,4 +47,4 @@ EXPOSE 8000
 
 # Start development server by default
 ENTRYPOINT ["mkdocs"]
-CMD ["serve", "--dev-addr=0.0.0.0:8000"]
+CMD ["serve"]


### PR DESCRIPTION
…s the default site_url.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
