### PR TITLE
GSYE-524: Did not override the market_cycle on the SCMForecastExterna…

### DIFF
--- a/src/gsy_e/models/strategy/energy_parameters/load.py
+++ b/src/gsy_e/models/strategy/energy_parameters/load.py
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+import logging
 from typing import Dict, List, Optional
 
 from gsy_framework.utils import (
@@ -28,6 +29,8 @@ from gsy_e.gsy_e_core.exceptions import GSyException
 from gsy_e.models.strategy.state import LoadState
 from gsy_e.models.strategy import utils
 from gsy_e.models.strategy.profile import EnergyProfile
+
+log = logging.getLogger(__name__)
 
 
 class LoadHoursEnergyParameters:
@@ -205,6 +208,9 @@ class DefinedLoadEnergyParameters(LoadHoursPerDayEnergyParameters):
                 "without a profile.")
         load_energy_kwh = find_object_of_same_weekday_and_time(
             self.energy_profile.profile, time_slot)
+        if load_energy_kwh is None:
+            log.error("Could not read area %s profile on timeslot %s.", self._area, time_slot)
+            load_energy_kwh = 0.0
         self.state.set_desired_energy(load_energy_kwh * 1000, time_slot, overwrite=False)
         self.state.update_total_demanded_energy(time_slot)
 

--- a/src/gsy_e/models/strategy/energy_parameters/pv.py
+++ b/src/gsy_e/models/strategy/energy_parameters/pv.py
@@ -15,7 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
+import logging
 import math
 import pathlib
 
@@ -28,9 +28,11 @@ from pendulum.datetime import DateTime
 
 from gsy_e.gsy_e_core.exceptions import GSyException
 from gsy_e.gsy_e_core.util import gsye_root_path
-from gsy_e.models.strategy.state import PVState
 from gsy_e.models.strategy import utils
 from gsy_e.models.strategy.profile import EnergyProfile
+from gsy_e.models.strategy.state import PVState
+
+log = logging.getLogger(__name__)
 
 
 class PVEnergyParameters:
@@ -204,4 +206,7 @@ class PVUserProfileEnergyParameters(PVEnergyParameters):
         for time_slot in time_slots:
             available_energy_kWh = find_object_of_same_weekday_and_time(
                 self.energy_profile.profile, time_slot) * self.panel_count
+            if available_energy_kWh is None:
+                log.error("Could not read area %s profile on timeslot %s.", owner_name, time_slot)
+                available_energy_kWh = 0.0
             self._state.set_available_energy(available_energy_kWh, time_slot, reconfigure)

--- a/src/gsy_e/models/strategy/scm/external/forecast_mixin.py
+++ b/src/gsy_e/models/strategy/scm/external/forecast_mixin.py
@@ -66,8 +66,8 @@ class SCMForecastExternalMixin(ForecastExternalMixin):
         """Return the progress information of the simulation."""
         return {"market_slot": self.owner.current_market_time_slot.format(DATE_TIME_FORMAT)}
 
-    def market_cycle(self, _area) -> None:
-        """Call forecast and measurement update."""
-        self.update_energy_forecast()
-        self.update_energy_measurement()
-        self._clear_energy_buffers()
+    # def market_cycle(self, _area) -> None:
+    #     """Call forecast and measurement update."""
+    #     self.update_energy_forecast()
+    #     self.update_energy_measurement()
+    #     self._clear_energy_buffers()

--- a/src/gsy_e/models/strategy/scm/external/load.py
+++ b/src/gsy_e/models/strategy/scm/external/load.py
@@ -22,8 +22,9 @@ from gsy_e.models.strategy.scm.load import SCMLoadProfileStrategy
 class ForecastSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
     """External SCM Load strategy"""
 
-    def _update_energy_requirement(self, _area):
-        """Overwrite method that sets the energy requirement in the state."""
+    # def _update_energy_requirement(self, _area):
+    #     """Overwrite method that sets the energy requirement in the state."""
+    #
 
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""

--- a/src/gsy_e/models/strategy/scm/external/pv.py
+++ b/src/gsy_e/models/strategy/scm/external/pv.py
@@ -29,8 +29,8 @@ class ForecastSCMPVStrategy(SCMForecastExternalMixin, SCMPVUserProfile):
         """TODO: Remove quickfix of GSYE-581 and remove the unused capacity_kW"""
         super().__init__(power_profile=power_profile, power_profile_uuid=power_profile_uuid)
 
-    def _update_forecast_in_state(self, _area):
-        """Overwrite method that sets the forecasted energy in the state."""
+    # def _update_forecast_in_state(self, _area):
+    #     """Overwrite method that sets the forecasted energy in the state."""
 
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""


### PR DESCRIPTION
…lMixin class, in order to disable the Redis measurement and forecast reading in favor of direct database readings.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
