### PR TITLE
Adapted the GlobalConfig duration to the adapted config duration when…

### DIFF
--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -195,6 +195,7 @@ def _handle_scm_past_slots_simulation_run(
         config.end_date = now(tz=pendulum.UTC).subtract(
             days=gsy_e.constants.SCM_CN_DAYS_OF_DELAY)
         config.sim_duration = config.end_date - config.start_date
+        GlobalConfig.sim_duration = config.sim_duration
         GlobalConfig.IS_CANARY_NETWORK = False
         gsy_e.constants.RUN_IN_REALTIME = False
         run_simulation(setup_module_name=scenario_name,


### PR DESCRIPTION
… ran in SCM past slots mode.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
