### PR TITLE
Reenabled the market_cycle method on the forecast mixin in order to p…

### DIFF
--- a/src/gsy_e/models/strategy/scm/external/forecast_mixin.py
+++ b/src/gsy_e/models/strategy/scm/external/forecast_mixin.py
@@ -66,8 +66,9 @@ class SCMForecastExternalMixin(ForecastExternalMixin):
         """Return the progress information of the simulation."""
         return {"market_slot": self.owner.current_market_time_slot.format(DATE_TIME_FORMAT)}
 
-    # def market_cycle(self, _area) -> None:
-    #     """Call forecast and measurement update."""
-    #     self.update_energy_forecast()
-    #     self.update_energy_measurement()
-    #     self._clear_energy_buffers()
+    def market_cycle(self, _area) -> None:
+        """Call forecast and measurement update."""
+        super().market_cycle(_area)
+        self.update_energy_forecast()
+        self.update_energy_measurement()
+        self._clear_energy_buffers()

--- a/src/gsy_e/models/strategy/scm/external/load.py
+++ b/src/gsy_e/models/strategy/scm/external/load.py
@@ -24,7 +24,6 @@ class ForecastSCMLoadStrategy(SCMForecastExternalMixin, SCMLoadProfileStrategy):
 
     # def _update_energy_requirement(self, _area):
     #     """Overwrite method that sets the energy requirement in the state."""
-    #
 
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""


### PR DESCRIPTION
…rocess first the normal market cycle and then override with any measurements that might have been received via the API connection.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
