### PR TITLE
GSYE-637: Corrected the SCM past slots operation mode, by passing the…

### DIFF
--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -209,6 +209,11 @@ def _handle_scm_past_slots_simulation_run(
 
     config = _create_config_settings_object(
         scenario_copy, settings_copy, aggregator_device_mapping)
+    # We are running SCM Canary Networks with some days of delay compared to realtime in order to
+    # compensate for delays in transmission of the asset measurements.
+    # Adding 4 hours of extra time to the SCM past slots simulation duration, in order to
+    # compensate for the runtime of the SCM past slots simulation and to not have any results gaps
+    # after this simulation run and the following Canary Network launch.
     config.end_date = now(tz=gsy_e.constants.TIME_ZONE).subtract(
         days=gsy_e.constants.SCM_CN_DAYS_OF_DELAY).add(hours=4)
     config.sim_duration = config.end_date - config.start_date

--- a/src/gsy_e/gsy_e_core/simulation/simulation.py
+++ b/src/gsy_e/gsy_e_core/simulation/simulation.py
@@ -20,7 +20,7 @@ import gc
 import os
 from logging import getLogger
 from time import sleep, time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 import psutil
 from gsy_framework.constants_limits import ConstSettings, GlobalConfig
@@ -528,12 +528,12 @@ def simulation_class_factory():
     )
 
 
-def run_simulation(setup_module_name: str = "", simulation_config: SimulationConfig = None,
-                   simulation_events: str = None,
-                   redis_job_id: str = None, saved_sim_state: dict = None,
-                   slot_length_realtime: Duration = None, kwargs: dict = None) -> None:
+def run_simulation(
+        setup_module_name: str = "", simulation_config: SimulationConfig = None,
+        simulation_events: str = None, redis_job_id: str = None, saved_sim_state: dict = None,
+        slot_length_realtime: Duration = None, kwargs: dict = None) -> Dict:
     """Initiate simulation class and start simulation."""
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,protected-access
     try:
         redis_job_id = (
             redis_job_id if not saved_sim_state
@@ -548,7 +548,7 @@ def run_simulation(setup_module_name: str = "", simulation_config: SimulationCon
         )
     except SimulationException as ex:
         log.error(ex)
-        return
+        return {}
 
     if (saved_sim_state and
             saved_sim_state["areas"] != {} and
@@ -558,3 +558,5 @@ def run_simulation(setup_module_name: str = "", simulation_config: SimulationCon
         simulation.run(initial_slot=saved_sim_state["general"]["slot_number"])
     else:
         simulation.run()
+
+    return simulation._results._endpoint_buffer.simulation_state

--- a/src/gsy_e/gsy_e_core/simulation/time_manager.py
+++ b/src/gsy_e/gsy_e_core/simulation/time_manager.py
@@ -23,6 +23,7 @@ from logging import getLogger
 from time import mktime, sleep, time
 from typing import TYPE_CHECKING, Tuple
 
+import pendulum
 from gsy_framework.constants_limits import ConstSettings
 from gsy_framework.enums import SpotMarketTypeEnum
 from pendulum import DateTime, duration, now
@@ -102,7 +103,7 @@ class SimulationTimeManager:
             sleep_time_s = config.tick_length.seconds - tick_runtime_s
         elif self.slot_length_realtime:
             current_expected_tick_time = self.tick_time_counter + self.tick_length_realtime_s
-            sleep_time_s = current_expected_tick_time - now().timestamp()
+            sleep_time_s = current_expected_tick_time - now(tz=TIME_ZONE).timestamp()
         else:
             return
 
@@ -154,7 +155,7 @@ class SimulationTimeManagerScm:
             sleep_time_s = config.slot_length.total_seconds() - slot_runtime_s
         elif slot_length_realtime_s:
             current_expected_slot_time = self.slot_time_counter + slot_length_realtime_s
-            sleep_time_s = current_expected_slot_time - now().timestamp()
+            sleep_time_s = current_expected_slot_time - now(tz=TIME_ZONE).timestamp()
         else:
             return
 
@@ -174,8 +175,8 @@ class SimulationTimeManagerScm:
         if gsy_e.constants.RUN_IN_REALTIME:
             slot_count = sys.maxsize
 
-            today = datetime.date.today()
-            seconds_since_midnight = time() - mktime(today.timetuple())
+            today = pendulum.today(tz=TIME_ZONE)
+            seconds_since_midnight = time() - today.int_timestamp
             slot_resume = int(seconds_since_midnight // config.slot_length.seconds) + 1
             seconds_elapsed_in_slot = seconds_since_midnight % config.slot_length.seconds
             sleep_time_s = config.slot_length.total_seconds() - seconds_elapsed_in_slot


### PR DESCRIPTION
… SCM simulation state from the past slots simulation run to the following Canary Network. Modified state in order to trick the subsequent Canary Network run that it is a running Canary Network that resumed operation.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
