### PR TITLE
GSYE-689: Proposal for passing measurements into scm strategies

### DIFF
--- a/src/gsy_e/models/strategy/energy_parameters/load.py
+++ b/src/gsy_e/models/strategy/energy_parameters/load.py
@@ -208,12 +208,18 @@ class DefinedLoadEnergyParameters(LoadHoursPerDayEnergyParameters):
             self.energy_profile.read_or_rotate_profiles(reconfigure=True)
 
     def update_energy_requirement(self, time_slot):
-        if not self.energy_profile.profile:
+        self._update_energy_requirement(self.energy_profile, time_slot)
+
+    def update_energy_requirement_measurement(self, time_slot):
+        self._update_energy_requirement(self.measurement_profile, time_slot)
+
+    def _update_energy_requirement(self, energy_profile, time_slot):
+        if not energy_profile.profile:
             raise GSyException(
                 "Load tries to set its energy forecasted requirement "
                 "without a profile.")
         load_energy_kwh = find_object_of_same_weekday_and_time(
-            self.energy_profile.profile, time_slot)
+            energy_profile.profile, time_slot)
         if load_energy_kwh is None:
             log.error("Could not read area profile %s on timeslot %s. Configuration %s.",
                       self.energy_profile.input_profile_uuid, time_slot,

--- a/src/gsy_e/models/strategy/energy_parameters/pv.py
+++ b/src/gsy_e/models/strategy/energy_parameters/pv.py
@@ -207,16 +207,22 @@ class PVUserProfileEnergyParameters(PVEnergyParameters):
             self.energy_profile.input_profile = kwargs["power_profile"]
         self.energy_profile.read_or_rotate_profiles(reconfigure=True)
 
-    def set_produced_energy_forecast_in_state(
-            self, owner_name, time_slots, reconfigure=True):
+    def set_produced_energy_forecast_in_state(self, owner_name, time_slots, reconfigure=True):
         """Update the production energy forecast."""
-        if not self.energy_profile.profile:
+        self._set_produced_energy(self.energy_profile, owner_name, time_slots, reconfigure)
+
+    def set_produced_energy_measurement_in_state(self, owner_name, time_slots, reconfigure=True):
+        self._set_produced_energy(self.measurement_profile, owner_name, time_slots, reconfigure)
+
+    def _set_produced_energy(self, energy_profile, owner_name, time_slots, reconfigure=True):
+        """Update the production energy forecast."""
+        if not energy_profile.profile:
             raise GSyException(
                 f"PV {owner_name} tries to set its available energy forecast without a "
                 "power profile.")
         for time_slot in time_slots:
             energy_from_profile_kWh = find_object_of_same_weekday_and_time(
-                self.energy_profile.profile, time_slot)
+                energy_profile.profile, time_slot)
             if energy_from_profile_kWh is None:
                 log.error("Could not read area %s profile on timeslot %s. Configuration %s.",
                           owner_name, time_slot, gsy_e.constants.CONFIGURATION_ID)

--- a/src/gsy_e/models/strategy/energy_parameters/smart_meter.py
+++ b/src/gsy_e/models/strategy/energy_parameters/smart_meter.py
@@ -55,19 +55,27 @@ class SmartMeterEnergyParameters:
             area_name=area_name)
 
     def set_energy_forecast_for_future_markets(self, time_slots, reconfigure: bool = True):
+        self._set_energy_forecast_for_future_markets(self._energy_profile, time_slots, reconfigure)
+
+    def set_energy_measurement_for_future_markets(self, time_slots, reconfigure: bool = True):
+        self._set_energy_forecast_for_future_markets(
+            self._measurement_profile, time_slots, reconfigure)
+
+    def _set_energy_forecast_for_future_markets(
+            self, energy_profile, time_slots, reconfigure: bool = True):
         """Set the energy consumption/production expectations for the upcoming market slots.
 
         Args:
             reconfigure: if True, re-read and preprocess the raw profile data.
         """
-        if not self._energy_profile.profile:
+        if not energy_profile.profile:
             raise GSyException(
                 f"Smart Meter {self._area.name} tries to set its required energy forecast without "
                 "a profile.")
 
         for slot_time in time_slots:
             energy_kWh = find_object_of_same_weekday_and_time(
-                self._energy_profile.profile, slot_time)
+                energy_profile.profile, slot_time)
             # For the Smart Meter, the energy amount can be either positive (consumption) or
             # negative (production).
             consumed_energy = energy_kWh if energy_kWh > 0 else 0.0

--- a/src/gsy_e/models/strategy/scm/load.py
+++ b/src/gsy_e/models/strategy/scm/load.py
@@ -83,7 +83,7 @@ class SCMLoadProfileStrategy(SCMStrategy):
 
     def _update_energy_requirement(self, area: "AreaBase") -> None:
         self._energy_params.energy_profile.read_or_rotate_profiles()
-        self._energy_params.update_energy_requirement(area.current_market_time_slot)
+        self._energy_params.update_energy_requirement_measurement(area.current_market_time_slot)
         self._energy_params.set_energy_measurement_kWh(area.past_market_time_slot)
 
     def market_cycle(self, area: "AreaBase") -> None:

--- a/src/gsy_e/models/strategy/scm/load.py
+++ b/src/gsy_e/models/strategy/scm/load.py
@@ -1,6 +1,7 @@
 from typing import Dict, TYPE_CHECKING
 
 from pendulum import DateTime
+from gsy_framework.constants_limits import GlobalConfig
 
 from gsy_e.models.strategy.energy_parameters.load import (
     LoadHoursEnergyParameters, DefinedLoadEnergyParameters)
@@ -83,7 +84,11 @@ class SCMLoadProfileStrategy(SCMStrategy):
 
     def _update_energy_requirement(self, area: "AreaBase") -> None:
         self._energy_params.energy_profile.read_or_rotate_profiles()
-        self._energy_params.update_energy_requirement_measurement(area.current_market_time_slot)
+        if GlobalConfig.is_canary_network():
+            self._energy_params.update_energy_requirement_measurement(
+                area.current_market_time_slot)
+        else:
+            self._energy_params.update_energy_requirement(area.current_market_time_slot)
         self._energy_params.set_energy_measurement_kWh(area.past_market_time_slot)
 
     def market_cycle(self, area: "AreaBase") -> None:

--- a/src/gsy_e/models/strategy/scm/pv.py
+++ b/src/gsy_e/models/strategy/scm/pv.py
@@ -52,10 +52,10 @@ class SCMPVUserProfile(SCMStrategy):
 
     def _update_forecast_in_state(self, area):
         self._energy_params.read_predefined_profile_for_pv()
-        self._energy_params.set_produced_energy_forecast_in_state(
+        self._energy_params.set_energy_measurement_kWh(area.current_market_time_slot)
+        self._energy_params.set_produced_energy_measurement_in_state(
             area.name, [area.current_market_time_slot], True
         )
-        self._energy_params.set_energy_measurement_kWh(area.current_market_time_slot)
 
     def activate(self, area: "AreaBase") -> None:
         self._energy_params.activate(area.config)

--- a/src/gsy_e/models/strategy/scm/pv.py
+++ b/src/gsy_e/models/strategy/scm/pv.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from typing import Union, Dict, TYPE_CHECKING
 
 from pendulum import DateTime
+from gsy_framework.constants_limits import GlobalConfig
 
 from gsy_e.models.strategy.energy_parameters.pv import PVUserProfileEnergyParameters
 from gsy_e.models.strategy.scm import SCMStrategy
@@ -53,9 +54,14 @@ class SCMPVUserProfile(SCMStrategy):
     def _update_forecast_in_state(self, area):
         self._energy_params.read_predefined_profile_for_pv()
         self._energy_params.set_energy_measurement_kWh(area.current_market_time_slot)
-        self._energy_params.set_produced_energy_measurement_in_state(
-            area.name, [area.current_market_time_slot], True
-        )
+        if GlobalConfig.is_canary_network():
+            self._energy_params.set_produced_energy_measurement_in_state(
+                area.name, [area.current_market_time_slot], True
+            )
+        else:
+            self._energy_params.set_produced_energy_forecast_in_state(
+                area.name, [area.current_market_time_slot], True
+            )
 
     def activate(self, area: "AreaBase") -> None:
         self._energy_params.activate(area.config)

--- a/src/gsy_e/models/strategy/scm/smart_meter.py
+++ b/src/gsy_e/models/strategy/scm/smart_meter.py
@@ -2,9 +2,11 @@ from pathlib import Path
 from typing import Union, Dict, TYPE_CHECKING
 
 from pendulum import DateTime
+from gsy_framework.constants_limits import GlobalConfig
 
 from gsy_e.models.strategy.scm import SCMStrategy
 from gsy_e.models.strategy.energy_parameters.smart_meter import SmartMeterEnergyParameters
+
 
 if TYPE_CHECKING:
     from gsy_e.models.area import CoefficientArea
@@ -39,8 +41,12 @@ class SCMSmartMeterStrategy(SCMStrategy):
 
     def market_cycle(self, area: "CoefficientArea") -> None:
         """Update the storage state for the next time slot."""
-        self._energy_params.set_energy_measurement_for_future_markets(
-            [area.current_market_time_slot], reconfigure=False)
+        if GlobalConfig.is_canary_network():
+            self._energy_params.set_energy_measurement_for_future_markets(
+                [area.current_market_time_slot], reconfigure=False)
+        else:
+            self._energy_params.set_energy_forecast_for_future_markets(
+                [area.current_market_time_slot], reconfigure=False)
         self._energy_params.set_energy_measurement_kWh(area.current_market_time_slot)
         self.state.delete_past_state_values(area.past_market_time_slot)
 

--- a/src/gsy_e/models/strategy/scm/smart_meter.py
+++ b/src/gsy_e/models/strategy/scm/smart_meter.py
@@ -16,10 +16,11 @@ class SCMSmartMeterStrategy(SCMStrategy):
     # pylint: disable=too-many-arguments
     def __init__(
             self, smart_meter_profile: Union[Path, str, Dict[int, float], Dict[str, float]] = None,
-            smart_meter_profile_uuid: str = None):
+            smart_meter_profile_uuid: str = None, smart_meter_measurement_uuid: str = None):
         self._energy_params = SmartMeterEnergyParameters(
-            smart_meter_profile, smart_meter_profile_uuid)
+            smart_meter_profile, smart_meter_profile_uuid, smart_meter_measurement_uuid)
         self.smart_meter_profile_uuid = smart_meter_profile_uuid
+        self.smart_meter_measurement_uuid = smart_meter_measurement_uuid
 
     @property
     def state(self) -> "SmartMeterState":
@@ -38,7 +39,7 @@ class SCMSmartMeterStrategy(SCMStrategy):
 
     def market_cycle(self, area: "CoefficientArea") -> None:
         """Update the storage state for the next time slot."""
-        self._energy_params.set_energy_forecast_for_future_markets(
+        self._energy_params.set_energy_measurement_for_future_markets(
             [area.current_market_time_slot], reconfigure=False)
         self._energy_params.set_energy_measurement_kWh(area.current_market_time_slot)
         self.state.delete_past_state_values(area.past_market_time_slot)

--- a/src/gsy_e/models/strategy/scm/storage.py
+++ b/src/gsy_e/models/strategy/scm/storage.py
@@ -1,6 +1,7 @@
 from typing import Dict, Union
 
 from pendulum import DateTime
+from gsy_framework.constants_limits import GlobalConfig
 
 from gsy_e.models.strategy.energy_parameters.storage_profile import StorageProfileEnergyParameters
 from gsy_e.models.strategy.scm import SCMStrategy
@@ -34,7 +35,9 @@ class SCMStorageStrategy(SCMStrategy):
         self._energy_params.market_cycle()
 
     def _get_from_profile(self, time_slot: DateTime) -> float:
-        return self._energy_params.energy_measurement.profile.get(time_slot)
+        if GlobalConfig.is_canary_network():
+            return self._energy_params.energy_measurement.profile.get(time_slot)
+        return self._energy_params.energy_profile.profile.get(time_slot)
 
     def get_energy_to_sell_kWh(self, time_slot: DateTime) -> float:
         """Get the available energy for production for the specified time slot."""

--- a/src/gsy_e/models/strategy/scm/storage.py
+++ b/src/gsy_e/models/strategy/scm/storage.py
@@ -34,7 +34,7 @@ class SCMStorageStrategy(SCMStrategy):
         self._energy_params.market_cycle()
 
     def _get_from_profile(self, time_slot: DateTime) -> float:
-        return self._energy_params.energy_profile.profile.get(time_slot)
+        return self._energy_params.energy_measurement.profile.get(time_slot)
 
     def get_energy_to_sell_kWh(self, time_slot: DateTime) -> float:
         """Get the available energy for production for the specified time slot."""


### PR DESCRIPTION
## Reason for the proposed changes

When dealing with [this](https://github.com/gridsingularity/gsy-e/pull/1748#discussion_r1533546811) comment, I realised, that the SCM strategies are always reading from the forecast profiles. But in the CN case, they should read from the measurement profiles. This needs to be discussed. Also, we need to discuss whether the SCM strategies need both forecast and measurement profiles. Conceptually, we only need the measurement and would only need to create one entry in the DB per asset on the gsy-web side for the profile (in both CN and non-CN case). However this is probably an overkill and we can live with having both. But lets discuss.

## Proposed changes

Here I propose a quick and dirty way of handling the decision whether to use the measurement profile or the forecast profile in the SCM strategies. The correct way would be to have a separate implementation of the energy parameters for the SCM strategies. 

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=feature/GSYE-689
