### PR TITLE
GSYE-740: Use method get_from_profile_same_weekday_and_time for SCM s…

### DIFF
--- a/src/gsy_e/models/strategy/utils.py
+++ b/src/gsy_e/models/strategy/utils.py
@@ -16,6 +16,7 @@ see <http://www.gnu.org/licenses/>.
 import random
 
 from gsy_framework.constants_limits import ConstSettings
+from gsy_framework.enums import SpotMarketTypeEnum
 from gsy_framework.utils import limit_float_precision
 
 
@@ -41,3 +42,8 @@ def compute_altered_energy(
         return 0
 
     return limit_float_precision(altered_energy_kWh)
+
+
+def is_scm_simulation():
+    """Return true if simulation is an SCM one, false otherwise."""
+    return ConstSettings.MASettings.MARKET_TYPE == SpotMarketTypeEnum.COEFFICIENTS.value

--- a/tests/strategies/test_strategy_profile.py
+++ b/tests/strategies/test_strategy_profile.py
@@ -158,9 +158,8 @@ class TestEnergyProfile:
     @staticmethod
     def test_strategy_profile_get_value_returns_correctly_for_simulations(strategy_profile):
         assert strategy_profile.get_value(CUSTOM_DATETIME.add(minutes=15)) == 1
-
-        with pytest.raises(KeyError):
-            strategy_profile.get_value(CUSTOM_DATETIME.subtract(minutes=15))
+        # Does not raise an exception but return 0 in case of missing profile value
+        assert strategy_profile.get_value(CUSTOM_DATETIME.subtract(minutes=15)) == 0
 
     @staticmethod
     @patch("gsy_e.models.strategy.strategy_profile.GlobalConfig.is_canary_network", lambda: True)


### PR DESCRIPTION
…imulations in addition to Canary Networks. Do not raise an exception in case a timeslot in the profile is missing, but return 0 instead.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
