### PR TITLE
GSYE-807: Remove disable_home_self_consumption from scm properties

### DIFF
--- a/src/gsy_e/gsy_e_core/rq_job_handler.py
+++ b/src/gsy_e/gsy_e_core/rq_job_handler.py
@@ -207,9 +207,6 @@ def _configure_constants_constsettings(
         ConstSettings.SCMSettings.INTRACOMMUNITY_BASE_RATE_EUR = settings["scm"][
             "intracommunity_rate_base_eur"
         ]
-        gsy_e.constants.SCM_DISABLE_HOME_SELF_CONSUMPTION = settings["scm"][
-            "disable_home_self_consumption"
-        ]
         ConstSettings.SCMSettings.SELF_CONSUMPTION_TYPE = settings["scm"]["self_consumption_type"]
     else:
         assert spot_market_type is not SpotMarketTypeEnum.COEFFICIENTS.value

--- a/tests/test_gsy_core/test_rq_job_handler.py
+++ b/tests/test_gsy_core/test_rq_job_handler.py
@@ -82,7 +82,6 @@ class TestRqJobHandler:
                 "grid_fees_reduction": 0.45,
                 "intracommunity_rate_base_eur": 12,
                 "scm_cn_hours_of_delay": 4,
-                "disable_home_self_consumption": True,
                 "self_consumption_type": 1,
             },
         }


### PR DESCRIPTION
## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
