### PR TITLE
GSYE-839: Corrected savings calculation, taking into account by inclu…

### DIFF
--- a/src/gsy_e/models/area/scm_dataclasses.py
+++ b/src/gsy_e/models/area/scm_dataclasses.py
@@ -385,8 +385,6 @@ class AreaEnergyBills:  # pylint: disable=too-many-instance-attributes
             {
                 "fees": self.energy_rates.area_fees.prices_as_dict(),
                 "savings": self.savings,
-                "savings_from_sell_to_community": self.savings_from_sell_to_community,
-                "savings_from_buy_from_community": self.savings_from_buy_from_community,
                 "savings_percent": self.savings_percent,
                 "energy_benchmark": self.energy_benchmark,
                 "home_balance_kWh": self.home_balance_kWh,

--- a/src/gsy_e/models/area/scm_dataclasses.py
+++ b/src/gsy_e/models/area/scm_dataclasses.py
@@ -278,7 +278,7 @@ class AreaFees:
 
     grid_import_fee_const: float = 0.0
     grid_export_fee_const: float = 0.0
-    grid_fees_reduction: float = 0.0
+    grid_fees_reduction: float = 1.0
     per_kWh_fees: Dict[str, FeeContainer] = field(default_factory=dict)
     monthly_fees: Dict[str, FeeContainer] = field(default_factory=dict)
 
@@ -372,7 +372,6 @@ class AreaEnergyBills:  # pylint: disable=too-many-instance-attributes
     spent_to_grid: float = 0.0
     sold_to_grid: float = 0.0
     earned_from_grid: float = 0.0
-    self_consumed_savings: float = 0.0
     import_grid_fees: float = 0.0
     export_grid_fees: float = 0.0
     _min_community_savings_percent: float = 0.0
@@ -386,6 +385,8 @@ class AreaEnergyBills:  # pylint: disable=too-many-instance-attributes
             {
                 "fees": self.energy_rates.area_fees.prices_as_dict(),
                 "savings": self.savings,
+                "savings_from_sell_to_community": self.savings_from_sell_to_community,
+                "savings_from_buy_from_community": self.savings_from_buy_from_community,
                 "savings_percent": self.savings_percent,
                 "energy_benchmark": self.energy_benchmark,
                 "home_balance_kWh": self.home_balance_kWh,
@@ -444,10 +445,27 @@ class AreaEnergyBills:  # pylint: disable=too-many-instance-attributes
         self._max_community_savings_percent = max_savings_percent
 
     @property
+    def savings_from_buy_from_community(self):
+        """Include to the savings the additional revenue from the intracommunity trading."""
+        return self.bought_from_community * (
+            self.energy_rates.utility_rate_incl_fees - self.energy_rates.intracommunity_rate
+        )
+
+    @property
+    def savings_from_sell_to_community(self):
+        """
+        Include the savings due to the decreased intracommunity rate compared to the feed in
+        tariff.
+        """
+        return self.sold_to_community * (
+            self.energy_rates.intracommunity_rate - self.energy_rates.feed_in_tariff
+        )
+
+    @property
     def savings(self):
         """Absolute price savings of the home, compared to the base energy bill."""
-        savings_absolute = KPICalculationHelper().saving_absolute(
-            self.base_energy_bill_excl_revenue, self.gsy_energy_bill_excl_revenue
+        savings_absolute = (
+            self.savings_from_buy_from_community + self.savings_from_sell_to_community
         )
         assert savings_absolute > -FLOATING_POINT_TOLERANCE
         return savings_absolute
@@ -539,14 +557,17 @@ class AreaEnergyBillsWithoutSurplusTrade(AreaEnergyBills):
     """Dedicated AreaEnergyBills class, specific for the non-suplus trade SCM."""
 
     @property
-    def savings(self):
-        """Absolute price savings of the home, compared to the base energy bill."""
-        # The savings and the percentage might produce negative and huge percentage values
-        # in cases of production. This is due to the fact that the energy bill in these cases
-        # will be negative, and the producer will not have "savings". For a more realistic case
-        # the revenue should be omitted from the calculation of the savings, however this needs
-        # to be discussed.
-        return self.self_consumed_savings + self.gsy_energy_bill_revenue
+    def savings_from_buy_from_community(self):
+        """Include to the savings the additional revenue from the intracommunity trading."""
+        return self.bought_from_community * self.energy_rates.utility_rate_incl_fees
+
+    @property
+    def savings_from_sell_to_community(self):
+        """
+        Include the savings due to the decreased intracommunity rate compared to the feed in
+        tariff.
+        """
+        return self.gsy_energy_bill_revenue
 
     def calculate_base_energy_bill(
         self, home_data: HomeAfterMeterData, area_rates: AreaEnergyRates

--- a/src/gsy_e/models/area/scm_manager.py
+++ b/src/gsy_e/models/area/scm_manager.py
@@ -155,8 +155,6 @@ class SCMManager:
         home_bill = AreaEnergyBills(
             energy_rates=area_rates,
             gsy_energy_bill=area_rates.area_fees.total_monthly_fees,
-            self_consumed_savings=home_data.self_consumed_energy_kWh
-            * home_data.area_properties.AREA_PROPERTIES["market_maker_rate"],
         )
         home_bill.calculate_base_energy_bill(home_data, area_rates)
 
@@ -279,6 +277,9 @@ class SCMManager:
     def community_bills(self) -> Dict:
         """Calculate bills for the community."""
         community_bills = AreaEnergyBills()
+        savings_from_buy_from_community = 0.0
+        savings_from_sell_to_community = 0.0
+        savings = 0.0
         for data in self._bills.values():
             community_bills.base_energy_bill += data.base_energy_bill
             community_bills.base_energy_bill_revenue += data.base_energy_bill_revenue
@@ -299,7 +300,15 @@ class SCMManager:
             community_bills.import_grid_fees += data.import_grid_fees
             community_bills.export_grid_fees += data.export_grid_fees
 
-        return community_bills.to_dict()
+            savings_from_buy_from_community += data.savings_from_buy_from_community
+            savings_from_sell_to_community += data.savings_from_sell_to_community
+            savings += data.savings
+
+        comm_bills = community_bills.to_dict()
+        comm_bills["savings"] = savings
+        comm_bills["savings_from_buy_from_community"] = savings_from_buy_from_community
+        comm_bills["savings_from_sell_to_community"] = savings_from_sell_to_community
+        return comm_bills
 
 
 class SCMManagerWithoutSurplusTrade(SCMManager):
@@ -332,8 +341,6 @@ class SCMManagerWithoutSurplusTrade(SCMManager):
         home_bill = AreaEnergyBillsWithoutSurplusTrade(
             energy_rates=area_rates,
             gsy_energy_bill=area_rates.area_fees.total_monthly_fees,
-            self_consumed_savings=home_data.self_consumed_energy_kWh
-            * home_data.area_properties.AREA_PROPERTIES["market_maker_rate"],
         )
         home_bill.calculate_base_energy_bill(home_data, area_rates)
 

--- a/src/gsy_e/models/strategy/strategy_profile.py
+++ b/src/gsy_e/models/strategy/strategy_profile.py
@@ -39,8 +39,7 @@ class StrategyProfileBase(ABC):
 class EmptyProfile(StrategyProfileBase):
     """Empty profile class"""
 
-    def __init__(
-            self, profile_type: InputProfileTypes = None):
+    def __init__(self, profile_type: InputProfileTypes = None):
         super().__init__()
         self.profile = {}
         self.profile_type = profile_type
@@ -56,8 +55,12 @@ class StrategyProfile(StrategyProfileBase):
     """Manage reading/rotating energy profile of an asset."""
 
     def __init__(
-            self, input_profile=None, input_profile_uuid=None,
-            input_energy_rate=None, profile_type: InputProfileTypes = None):
+        self,
+        input_profile=None,
+        input_profile_uuid=None,
+        input_energy_rate=None,
+        profile_type: InputProfileTypes = None,
+    ):
         # pylint: disable=super-init-not-called
 
         self.input_profile = input_profile
@@ -79,23 +82,33 @@ class StrategyProfile(StrategyProfileBase):
         self.profile_type = profile_type
 
     def get_value(self, time_slot: DateTime) -> float:
+        if not self.profile:
+            return 0
         if time_slot in self.profile:
             return self.profile[time_slot]
         if GlobalConfig.is_canary_network() or is_scm_simulation():
             value = get_from_profile_same_weekday_and_time(self.profile, time_slot)
             if value is None:
-                log.error("Value for time_slot %s could not be found in profile %s in "
-                          "Canary Network, returning 0", time_slot, self.input_profile_uuid)
+                log.error(
+                    "Value for time_slot %s could not be found in profile %s in "
+                    "Canary Network, returning 0",
+                    time_slot,
+                    self.input_profile_uuid,
+                )
                 return 0
             return value
-        log.error("Value for time_slot %s could not be found in profile "
-                  "%s.", time_slot, self.input_profile_uuid)
+        log.error(
+            "Value for time_slot %s could not be found in profile %s.",
+            time_slot,
+            self.input_profile_uuid,
+        )
         return 0
 
     def _read_input_profile_type(self):
         if self.input_profile_uuid:
             self.profile_type = global_objects.profiles_handler.get_profile_type(
-                self.input_profile_uuid)
+                self.input_profile_uuid
+            )
         elif self.input_energy_rate is not None:
             self.profile_type = InputProfileTypes.IDENTITY
         else:
@@ -106,23 +119,28 @@ class StrategyProfile(StrategyProfileBase):
             self._read_input_profile_type()
 
         if not self.profile or reconfigure:
-            profile = (self.input_energy_rate
-                       if self.input_energy_rate is not None
-                       else self.input_profile)
+            profile = (
+                self.input_energy_rate
+                if self.input_energy_rate is not None
+                else self.input_profile
+            )
         else:
             profile = self.profile
 
         self.profile = global_objects.profiles_handler.rotate_profile(
-            profile_type=self.profile_type,
-            profile=profile,
-            profile_uuid=self.input_profile_uuid)
+            profile_type=self.profile_type, profile=profile, profile_uuid=self.input_profile_uuid
+        )
 
 
-def profile_factory(input_profile=None, input_profile_uuid=None,
-                    input_energy_rate=None,
-                    profile_type: InputProfileTypes = None) -> StrategyProfileBase:
+def profile_factory(
+    input_profile=None,
+    input_profile_uuid=None,
+    input_energy_rate=None,
+    profile_type: InputProfileTypes = None,
+) -> StrategyProfileBase:
     """Return correct profile handling class for input parameters."""
-    return (EmptyProfile(profile_type)
-            if input_profile is None and input_profile_uuid is None and input_energy_rate is None
-            else StrategyProfile(
-        input_profile, input_profile_uuid, input_energy_rate, profile_type))
+    return (
+        EmptyProfile(profile_type)
+        if input_profile is None and input_profile_uuid is None and input_energy_rate is None
+        else StrategyProfile(input_profile, input_profile_uuid, input_energy_rate, profile_type)
+    )


### PR DESCRIPTION
…ding the savings from the revenue in addition to the savings from buying energy from community. Corrected the default grid fee reduction value to be 1, so that intracommunity trading does not include any grid fees by default.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
