### PR TITLE
GSYE-830: Omit SCM requirement in case the SCM repo is not defined.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ try:
                 f"git+https://github.com/gridsingularity/gsy-framework.git@{gsy_framework_branch}"
             ]
         )
-        if scm_engine_branch:
+        if scm_engine_branch and scm_engine_repo:
             REQUIREMENTS.extend([f"scm-engine @ {scm_engine_repo}@{scm_engine_branch}"])
 except OSError:
     # Shouldn't happen


### PR DESCRIPTION
## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
**GSY_FRAMEWORK_BRANCH**=master
**SCM_ENGINE_BRANCH**=master
